### PR TITLE
ros1_bridge fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,35 +233,44 @@ endif()
 macro(targets)
   set(TEST_BRIDGE_RMW ${rmw_implementation})
 
-  configure_file(
-    test/test_topics_across_dynamic_bridge.py.in
-    test_topics_across_dynamic_bridge${target_suffix}.py.genexp
-    @ONLY
-  )
-  file(GENERATE
-    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_topics_across_dynamic_bridge${target_suffix}_$<CONFIG>.py"
-    INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_topics_across_dynamic_bridge${target_suffix}.py.genexp"
-  )
-  add_launch_test(
-    "${CMAKE_CURRENT_BINARY_DIR}/test_topics_across_dynamic_bridge${target_suffix}_$<CONFIG>.py"
-    TARGET test_topics_across_dynamic_bridge${target_suffix}
-    ENV RMW_IMPLEMENTATION=${rmw_implementation}
-    TIMEOUT 60)
+  list(LENGTH DYNAMIC_BRIDGE_TYPE count)
+  math(EXPR count "${count}-1")
+  foreach(i RANGE ${count})
+    list(GET DYNAMIC_BRIDGE_TYPE ${i} bridge_type)
+    list(GET DYNAMIC_BRIDGE_ARG ${i} bridge_arg)
+    set(TEST_BRIDGE_DYNAMIC_BRIDGE_ARG "${bridge_arg}")
 
-  configure_file(
-    test/test_services_across_dynamic_bridge.py.in
-    test_services_across_dynamic_bridge${target_suffix}.py.genexp
-    @ONLY
-  )
-  file(GENERATE
-    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_services_across_dynamic_bridge${target_suffix}_$<CONFIG>.py"
-    INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_services_across_dynamic_bridge${target_suffix}.py.genexp"
-  )
-  add_launch_test(
-    "${CMAKE_CURRENT_BINARY_DIR}/test_services_across_dynamic_bridge${target_suffix}_$<CONFIG>.py"
-    TARGET test_services_across_dynamic_bridge${target_suffix}
-    ENV RMW_IMPLEMENTATION=${rmw_implementation}
-    TIMEOUT 60)
+    configure_file(
+      test/test_topics_across_dynamic_bridge.py.in
+      test_topics_across_dynamic_bridge${target_suffix}_${bridge_type}.py.genexp
+      @ONLY
+    )
+    file(GENERATE
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_topics_across_dynamic_bridge${target_suffix}_${bridge_type}_$<CONFIG>.py"
+      INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_topics_across_dynamic_bridge${target_suffix}_${bridge_type}.py.genexp"
+    )
+    add_launch_test(
+      "${CMAKE_CURRENT_BINARY_DIR}/test_topics_across_dynamic_bridge${target_suffix}_${bridge_type}_$<CONFIG>.py"
+      TARGET test_topics_across_dynamic_bridge${target_suffix}_${bridge_type}
+      ENV RMW_IMPLEMENTATION=${rmw_implementation}
+      TIMEOUT 60)
+
+    configure_file(
+      test/test_services_across_dynamic_bridge.py.in
+      test_services_across_dynamic_bridge${target_suffix}_${bridge_type}.py.genexp
+      @ONLY
+    )
+    file(GENERATE
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_services_across_dynamic_bridge${target_suffix}_${bridge_type}_$<CONFIG>.py"
+      INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_services_across_dynamic_bridge${target_suffix}_${bridge_type}.py.genexp"
+    )
+    add_launch_test(
+      "${CMAKE_CURRENT_BINARY_DIR}/test_services_across_dynamic_bridge${target_suffix}_${bridge_type}_$<CONFIG>.py"
+      TARGET test_services_across_dynamic_bridge${target_suffix}_${bridge_type}
+      ENV RMW_IMPLEMENTATION=${rmw_implementation}
+      TIMEOUT 60)
+  endforeach()
+
 endmacro()
 
 if(TEST_ROS1_BRIDGE)
@@ -275,6 +284,12 @@ if(TEST_ROS1_BRIDGE)
   set(TEST_BRIDGE_ROSCORE "${ros1_roslaunch_PREFIX}/bin/roscore")
   set(TEST_BRIDGE_ROS1_CLIENT "$<TARGET_FILE:test_ros1_client>")
   set(TEST_BRIDGE_ROS1_SERVER "$<TARGET_FILE:test_ros1_server>")
+
+  list(APPEND DYNAMIC_BRIDGE_TYPE "st")
+  list(APPEND DYNAMIC_BRIDGE_ARG " ")
+
+  list(APPEND DYNAMIC_BRIDGE_TYPE "mt")
+  list(APPEND DYNAMIC_BRIDGE_ARG "--multi-threads")
 
   call_for_each_rmw_implementation(targets)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
 find_package(std_msgs REQUIRED)
-find_package(xmlrpcpp REQUIRED)
 
 # find ROS 1 packages
 set(cmake_extras_files cmake/find_ros1_package.cmake cmake/find_ros1_interface_packages.cmake)
@@ -44,6 +43,10 @@ if(NOT ros1_roscpp_FOUND)
 endif()
 
 find_ros1_package(std_msgs REQUIRED)
+
+# Dependency that we should only look for if ROS 1 is installed (it's not present on a ROS 2
+# system; see https://github.com/ros2/ros1_bridge/pull/331#issuecomment-1188111510)
+find_package(xmlrpcpp REQUIRED)
 
 # find ROS 1 packages with messages / services
 include(cmake/find_ros1_interface_packages.cmake)

--- a/include/ros1_bridge/bridge.hpp
+++ b/include/ros1_bridge/bridge.hpp
@@ -104,7 +104,8 @@ create_bridge_from_2_to_1(
   const std::string & ros1_type_name,
   const std::string & ros1_topic_name,
   size_t publisher_queue_size,
-  rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr);
+  rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr,
+  bool custom_callback_group = false);
 
 Bridge2to1Handles
 create_bridge_from_2_to_1(
@@ -116,7 +117,8 @@ create_bridge_from_2_to_1(
   const std::string & ros1_type_name,
   const std::string & ros1_topic_name,
   size_t publisher_queue_size,
-  rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr);
+  rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr,
+  bool custom_callback_group = false);
 
 BridgeHandles
 create_bidirectional_bridge(
@@ -125,7 +127,8 @@ create_bidirectional_bridge(
   const std::string & ros1_type_name,
   const std::string & ros2_type_name,
   const std::string & topic_name,
-  size_t queue_size = 10);
+  size_t queue_size = 10,
+  bool custom_callback_group = false);
 
 BridgeHandles
 create_bidirectional_bridge(

--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -33,6 +33,20 @@
 namespace ros1_bridge
 {
 
+static rclcpp::CallbackGroup::SharedPtr get_callback_group(rclcpp::Node::SharedPtr ros2_node)
+{
+  auto node_base = ros2_node->get_node_base_interface();
+  auto group = node_base->get_default_callback_group();
+  auto callback_groups = node_base->get_callback_groups();
+  if (callback_groups.size() > 1) {
+    auto group_lock = callback_groups[1].lock();
+    if (group_lock) {
+      group = group_lock;
+    }
+  }
+  return group;
+}
+
 template<typename ROS1_T, typename ROS2_T>
 class Factory : public FactoryInterface
 {
@@ -145,6 +159,7 @@ public:
       ros1_pub, ros1_type_name_, ros2_type_name_, node->get_logger(), ros2_pub);
     rclcpp::SubscriptionOptions options;
     options.ignore_local_publications = true;
+    options.callback_group = ros1_bridge::get_callback_group(node);
     return node->create_subscription<ROS2_T>(
       topic_name, qos, callback, options);
   }
@@ -332,10 +347,9 @@ public:
     int service_execution_timeout)
   {
     ServiceBridge1to2 bridge;
-    bridge.group = ros2_node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
     bridge.client = ros2_node->create_client<ROS2_T>(
       name, rmw_qos_profile_services_default,
-      bridge.group);
+      ros1_bridge::get_callback_group(ros2_node));
     auto m = &ServiceFactory<ROS1_T, ROS2_T>::forward_1_to_2;
     auto f = std::bind(
       m, this, bridge.client, ros2_node->get_logger(), std::placeholders::_1,
@@ -358,10 +372,9 @@ public:
     f = std::bind(
       m, this, bridge.client, ros2_node->get_logger(), std::placeholders::_1,
       std::placeholders::_2, std::placeholders::_3);
-    bridge.group = ros2_node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
     bridge.server = ros2_node->create_service<ROS2_T>(
       name, f, rmw_qos_profile_services_default,
-      bridge.group);
+      ros1_bridge::get_callback_group(ros2_node));
     return bridge;
   }
 

--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -39,25 +39,23 @@ static rclcpp::CallbackGroup::SharedPtr get_callback_group(
   const std::string & topic_name = "")
 {
   auto node_base = ros2_node->get_node_base_interface();
-  auto group = node_base->get_default_callback_group();
-  if (topic_name.empty()) {
-    // create a callback group with Reentrant for creating ros2 clients and services
-    static auto s_shared_callbackgroup =
-      ros2_node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
-    return s_shared_callbackgroup;
-  }
+  rclcpp::CallbackGroup::SharedPtr group = nullptr;
 
-  typedef std::map<std::string, rclcpp::CallbackGroup::SharedPtr> TopicCallbackGroupMap;
-  static TopicCallbackGroupMap s_topic_callbackgroups;
-  auto iter = s_topic_callbackgroups.find(topic_name);
-  if (iter != s_topic_callbackgroups.end()) {
+  typedef std::map<std::string, rclcpp::CallbackGroup::SharedPtr> CallbackGroupMap;
+  static CallbackGroupMap s_callbackgroups;
+  auto iter = s_callbackgroups.find(topic_name);
+  if (iter != s_callbackgroups.end()) {
     return iter->second;
   }
 
-  // create one CallbackGroup with MutuallyExclusive for each topic
-  // to ensure that the message data of each topic is received in order
-  group = ros2_node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  s_topic_callbackgroups.insert({topic_name, group});
+  group = ros2_node->create_callback_group(
+    topic_name.empty() ?
+    // create a shared callback group with Reentrant for creating all ros2 clients and services
+    rclcpp::CallbackGroupType::Reentrant :
+    // create one CallbackGroup with MutuallyExclusive for each topic
+    // to ensure that the message data of each topic is received in order
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+  s_callbackgroups.insert({topic_name, group});
 
   return group;
 }
@@ -139,10 +137,12 @@ public:
     const std::string & topic_name,
     size_t queue_size,
     ros::Publisher ros1_pub,
-    rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr)
+    rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr,
+    bool custom_callback_group = false)
   {
     auto qos = rclcpp::SensorDataQoS(rclcpp::KeepLast(queue_size));
-    return create_ros2_subscriber(node, topic_name, qos, ros1_pub, ros2_pub);
+    return create_ros2_subscriber(
+      node, topic_name, qos, ros1_pub, ros2_pub, custom_callback_group);
   }
 
   rclcpp::SubscriptionBase::SharedPtr
@@ -151,12 +151,13 @@ public:
     const std::string & topic_name,
     const rmw_qos_profile_t & qos,
     ros::Publisher ros1_pub,
-    rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr)
+    rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr,
+    bool custom_callback_group = false)
   {
     auto rclcpp_qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos));
     rclcpp_qos.get_rmw_qos_profile() = qos;
     return create_ros2_subscriber(
-      node, topic_name, rclcpp_qos, ros1_pub, ros2_pub);
+      node, topic_name, rclcpp_qos, ros1_pub, ros2_pub, custom_callback_group);
   }
 
   rclcpp::SubscriptionBase::SharedPtr
@@ -165,7 +166,8 @@ public:
     const std::string & topic_name,
     const rclcpp::QoS & qos,
     ros::Publisher ros1_pub,
-    rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr)
+    rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr,
+    bool custom_callback_group = false)
   {
     std::function<
       void(const typename ROS2_T::SharedPtr msg, const rclcpp::MessageInfo & msg_info)> callback;
@@ -174,7 +176,9 @@ public:
       ros1_pub, ros1_type_name_, ros2_type_name_, node->get_logger(), ros2_pub);
     rclcpp::SubscriptionOptions options;
     options.ignore_local_publications = true;
-    options.callback_group = ros1_bridge::get_callback_group(node, topic_name);
+    if (custom_callback_group) {
+      options.callback_group = ros1_bridge::get_callback_group(node, topic_name);
+    }
     return node->create_subscription<ROS2_T>(
       topic_name, qos, callback, options);
   }
@@ -359,12 +363,15 @@ public:
 
   ServiceBridge1to2 service_bridge_1_to_2(
     ros::NodeHandle & ros1_node, rclcpp::Node::SharedPtr ros2_node, const std::string & name,
-    int service_execution_timeout)
+    int service_execution_timeout, bool custom_callback_group = false)
   {
     ServiceBridge1to2 bridge;
+    rclcpp::CallbackGroup::SharedPtr group = nullptr;
+    if (custom_callback_group) {
+      group = ros1_bridge::get_callback_group(ros2_node);
+    }
     bridge.client = ros2_node->create_client<ROS2_T>(
-      name, rmw_qos_profile_services_default,
-      ros1_bridge::get_callback_group(ros2_node));
+      name, rmw_qos_profile_services_default, group);
     auto m = &ServiceFactory<ROS1_T, ROS2_T>::forward_1_to_2;
     auto f = std::bind(
       m, this, bridge.client, ros2_node->get_logger(), std::placeholders::_1,
@@ -374,7 +381,8 @@ public:
   }
 
   ServiceBridge2to1 service_bridge_2_to_1(
-    ros::NodeHandle & ros1_node, rclcpp::Node::SharedPtr ros2_node, const std::string & name)
+    ros::NodeHandle & ros1_node, rclcpp::Node::SharedPtr ros2_node, const std::string & name,
+    bool custom_callback_group = false)
   {
     ServiceBridge2to1 bridge;
     bridge.client = ros1_node.serviceClient<ROS1_T>(name);
@@ -387,9 +395,12 @@ public:
     f = std::bind(
       m, this, bridge.client, ros2_node->get_logger(), std::placeholders::_1,
       std::placeholders::_2, std::placeholders::_3);
+    rclcpp::CallbackGroup::SharedPtr group = nullptr;
+    if (custom_callback_group) {
+      group = ros1_bridge::get_callback_group(ros2_node);
+    }
     bridge.server = ros2_node->create_service<ROS2_T>(
-      name, f, rmw_qos_profile_services_default,
-      ros1_bridge::get_callback_group(ros2_node));
+      name, f, rmw_qos_profile_services_default, group);
     return bridge;
   }
 

--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -333,7 +333,9 @@ public:
   {
     ServiceBridge1to2 bridge;
     bridge.group = ros2_node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
-    bridge.client = ros2_node->create_client<ROS2_T>(name, rmw_qos_profile_services_default, bridge.group);
+    bridge.client = ros2_node->create_client<ROS2_T>(
+      name, rmw_qos_profile_services_default,
+      bridge.group);
     auto m = &ServiceFactory<ROS1_T, ROS2_T>::forward_1_to_2;
     auto f = std::bind(
       m, this, bridge.client, ros2_node->get_logger(), std::placeholders::_1,
@@ -357,7 +359,9 @@ public:
       m, this, bridge.client, ros2_node->get_logger(), std::placeholders::_1,
       std::placeholders::_2, std::placeholders::_3);
     bridge.group = ros2_node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
-    bridge.server = ros2_node->create_service<ROS2_T>(name, f, rmw_qos_profile_services_default, bridge.group);
+    bridge.server = ros2_node->create_service<ROS2_T>(
+      name, f, rmw_qos_profile_services_default,
+      bridge.group);
     return bridge;
   }
 

--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -322,7 +322,7 @@ public:
     if (client.call(srv)) {
       translate_1_to_2(srv.response, *response);
     } else {
-      throw std::runtime_error("Failed to get response from ROS 1 service " + client.getService());
+      RCLCPP_ERROR(logger, "Failed to get response from ROS 1 service %s", client.getService());
     }
   }
 

--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -16,6 +16,7 @@
 #define  ROS1_BRIDGE__FACTORY_HPP_
 
 #include <functional>
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>

--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -332,7 +332,8 @@ public:
     int service_execution_timeout)
   {
     ServiceBridge1to2 bridge;
-    bridge.client = ros2_node->create_client<ROS2_T>(name);
+    bridge.group = ros2_node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+    bridge.client = ros2_node->create_client<ROS2_T>(name, rmw_qos_profile_services_default, bridge.group);
     auto m = &ServiceFactory<ROS1_T, ROS2_T>::forward_1_to_2;
     auto f = std::bind(
       m, this, bridge.client, ros2_node->get_logger(), std::placeholders::_1,
@@ -355,7 +356,8 @@ public:
     f = std::bind(
       m, this, bridge.client, ros2_node->get_logger(), std::placeholders::_1,
       std::placeholders::_2, std::placeholders::_3);
-    bridge.server = ros2_node->create_service<ROS2_T>(name, f);
+    bridge.group = ros2_node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+    bridge.server = ros2_node->create_service<ROS2_T>(name, f, rmw_qos_profile_services_default, bridge.group);
     return bridge;
   }
 

--- a/include/ros1_bridge/factory_interface.hpp
+++ b/include/ros1_bridge/factory_interface.hpp
@@ -90,7 +90,8 @@ public:
     const std::string & topic_name,
     size_t queue_size,
     ros::Publisher ros1_pub,
-    rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr) = 0;
+    rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr,
+    bool custom_callback_group = false) = 0;
 
   virtual
   rclcpp::SubscriptionBase::SharedPtr
@@ -99,7 +100,8 @@ public:
     const std::string & topic_name,
     const rmw_qos_profile_t & qos_profile,
     ros::Publisher ros1_pub,
-    rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr) = 0;
+    rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr,
+    bool custom_callback_group = false) = 0;
 
   virtual
   rclcpp::SubscriptionBase::SharedPtr
@@ -108,7 +110,8 @@ public:
     const std::string & topic_name,
     const rclcpp::QoS & qos,
     ros::Publisher ros1_pub,
-    rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr) = 0;
+    rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr,
+    bool custom_callback_group = false) = 0;
 
   virtual
   void
@@ -123,10 +126,12 @@ class ServiceFactoryInterface
 {
 public:
   virtual ServiceBridge1to2 service_bridge_1_to_2(
-    ros::NodeHandle &, rclcpp::Node::SharedPtr, const std::string &, int) = 0;
+    ros::NodeHandle &, rclcpp::Node::SharedPtr, const std::string &,
+    bool custom_callback_group = false) = 0;
 
   virtual ServiceBridge2to1 service_bridge_2_to_1(
-    ros::NodeHandle &, rclcpp::Node::SharedPtr, const std::string &) = 0;
+    ros::NodeHandle &, rclcpp::Node::SharedPtr, const std::string &,
+    bool custom_callback_group = false) = 0;
 };
 
 }  // namespace ros1_bridge

--- a/include/ros1_bridge/factory_interface.hpp
+++ b/include/ros1_bridge/factory_interface.hpp
@@ -33,13 +33,11 @@ namespace ros1_bridge
 struct ServiceBridge1to2
 {
   ros::ServiceServer server;
-  rclcpp::CallbackGroup::SharedPtr group;
   rclcpp::ClientBase::SharedPtr client;
 };
 
 struct ServiceBridge2to1
 {
-  rclcpp::CallbackGroup::SharedPtr group;
   rclcpp::ServiceBase::SharedPtr server;
   ros::ServiceClient client;
 };

--- a/include/ros1_bridge/factory_interface.hpp
+++ b/include/ros1_bridge/factory_interface.hpp
@@ -33,11 +33,13 @@ namespace ros1_bridge
 struct ServiceBridge1to2
 {
   ros::ServiceServer server;
+  rclcpp::CallbackGroup::SharedPtr group;
   rclcpp::ClientBase::SharedPtr client;
 };
 
 struct ServiceBridge2to1
 {
+  rclcpp::CallbackGroup::SharedPtr group;
   rclcpp::ServiceBase::SharedPtr server;
   ros::ServiceClient client;
 };

--- a/include/ros1_bridge/factory_interface.hpp
+++ b/include/ros1_bridge/factory_interface.hpp
@@ -126,7 +126,7 @@ class ServiceFactoryInterface
 {
 public:
   virtual ServiceBridge1to2 service_bridge_1_to_2(
-    ros::NodeHandle &, rclcpp::Node::SharedPtr, const std::string &,
+    ros::NodeHandle &, rclcpp::Node::SharedPtr, const std::string &, int,
     bool custom_callback_group = false) = 0;
 
   virtual ServiceBridge2to1 service_bridge_2_to_1(

--- a/include/ros1_bridge/helper.hpp
+++ b/include/ros1_bridge/helper.hpp
@@ -1,0 +1,579 @@
+#pragma once
+
+
+#include <xmlrpcpp/XmlRpcException.h>
+
+// include ROS 1
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+#include "ros/callback_queue.h"
+#include "ros/ros.h"
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#include "ros/this_node.h"
+#include "ros/header.h"
+#include "ros/service_manager.h"
+#include "ros/transport/transport_tcp.h"
+
+// include ROS 2
+#include "rclcpp/rclcpp.hpp"
+#include "rcpputils/scope_exit.hpp"
+
+#include <list>
+#include <string>
+
+#include "ros1_bridge/bridge.hpp"
+
+namespace ros1_bridge {
+
+struct Bridge1to2HandlesAndMessageTypes
+{
+  ros1_bridge::Bridge1to2Handles bridge_handles;
+  std::string ros1_type_name;
+  std::string ros2_type_name;
+};
+
+struct Bridge2to1HandlesAndMessageTypes
+{
+  ros1_bridge::Bridge2to1Handles bridge_handles;
+  std::string ros1_type_name;
+  std::string ros2_type_name;
+};
+
+rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
+{
+  auto ros2_publisher_qos = rclcpp::QoS(rclcpp::KeepLast(10));
+
+  printf("Qos(");
+
+  if (qos_params.getType() == XmlRpc::XmlRpcValue::TypeStruct) {
+    if (qos_params.hasMember("history")) {
+      auto history = static_cast<std::string>(qos_params["history"]);
+      printf("history: ");
+      if (history == "keep_all") {
+        ros2_publisher_qos.keep_all();
+        printf("keep_all, ");
+      } else if (history == "keep_last") {
+        if (qos_params.hasMember("depth")) {
+          auto depth = static_cast<int>(qos_params["depth"]);
+          ros2_publisher_qos.keep_last(depth);
+          printf("keep_last(%i), ", depth);
+        } else {
+          fprintf(
+            stderr,
+            "history: keep_last requires that also a depth is set\n");
+        }
+      } else {
+        fprintf(
+          stderr,
+          "invalid value for 'history': '%s', allowed values are 'keep_all',"
+          "'keep_last' (also requires 'depth' to be set)\n",
+          history.c_str());
+      }
+    }
+
+    if (qos_params.hasMember("reliability")) {
+      auto reliability = static_cast<std::string>(qos_params["reliability"]);
+      printf("reliability: ");
+      if (reliability == "best_effort") {
+        ros2_publisher_qos.best_effort();
+        printf("best_effort, ");
+      } else if (reliability == "reliable") {
+        ros2_publisher_qos.reliable();
+        printf("reliable, ");
+      } else {
+        fprintf(
+          stderr,
+          "invalid value for 'reliability': '%s', allowed values are 'best_effort', 'reliable'\n",
+          reliability.c_str());
+      }
+    }
+
+    if (qos_params.hasMember("durability")) {
+      auto durability = static_cast<std::string>(qos_params["durability"]);
+      printf("durability: ");
+      if (durability == "transient_local") {
+        ros2_publisher_qos.transient_local();
+        printf("transient_local, ");
+      } else if (durability == "volatile") {
+        ros2_publisher_qos.durability_volatile();
+        printf("volatile, ");
+      } else {
+        fprintf(
+          stderr,
+          "invalid value for 'durability': '%s', allowed values are 'best_effort', 'volatile'\n",
+          durability.c_str());
+      }
+    }
+
+    if (qos_params.hasMember("deadline")) {
+      try {
+        rclcpp::Duration dur = rclcpp::Duration(
+          static_cast<int>(qos_params["deadline"]["secs"]),
+          static_cast<int>(qos_params["deadline"]["nsecs"]));
+        ros2_publisher_qos.deadline(dur);
+        printf("deadline: Duration(nsecs: %ld), ", dur.nanoseconds());
+      } catch (std::runtime_error & e) {
+        fprintf(
+          stderr,
+          "failed to parse deadline: '%s'\n",
+          e.what());
+      } catch (XmlRpc::XmlRpcException & e) {
+        fprintf(
+          stderr,
+          "failed to parse deadline: '%s'\n",
+          e.getMessage().c_str());
+      }
+    }
+
+    if (qos_params.hasMember("lifespan")) {
+      try {
+        rclcpp::Duration dur = rclcpp::Duration(
+          static_cast<int>(qos_params["lifespan"]["secs"]),
+          static_cast<int>(qos_params["lifespan"]["nsecs"]));
+        ros2_publisher_qos.lifespan(dur);
+        printf("lifespan: Duration(nsecs: %ld), ", dur.nanoseconds());
+      } catch (std::runtime_error & e) {
+        fprintf(
+          stderr,
+          "failed to parse lifespan: '%s'\n",
+          e.what());
+      } catch (XmlRpc::XmlRpcException & e) {
+        fprintf(
+          stderr,
+          "failed to parse lifespan: '%s'\n",
+          e.getMessage().c_str());
+      }
+    }
+
+    if (qos_params.hasMember("liveliness")) {
+      if (qos_params["liveliness"].getType() == XmlRpc::XmlRpcValue::TypeInt) {
+        try {
+          auto liveliness = static_cast<int>(qos_params["liveliness"]);
+          ros2_publisher_qos.liveliness(static_cast<rmw_qos_liveliness_policy_t>(liveliness));
+          printf("liveliness: %i, ", static_cast<int>(liveliness));
+        } catch (std::runtime_error & e) {
+          fprintf(
+            stderr,
+            "failed to parse liveliness: '%s'\n",
+            e.what());
+        } catch (XmlRpc::XmlRpcException & e) {
+          fprintf(
+            stderr,
+            "failed to parse liveliness: '%s'\n",
+            e.getMessage().c_str());
+        }
+      } else if (qos_params["liveliness"].getType() == XmlRpc::XmlRpcValue::TypeString) {
+        try {
+          rmw_qos_liveliness_policy_t liveliness =
+            rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
+          auto liveliness_str = static_cast<std::string>(qos_params["liveliness"]);
+          if (liveliness_str == "LIVELINESS_SYSTEM_DEFAULT" ||
+            liveliness_str == "liveliness_system_default")
+          {
+            liveliness = rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
+          } else if (liveliness_str == "LIVELINESS_AUTOMATIC" ||  // NOLINT
+            liveliness_str == "liveliness_automatic")
+          {
+            liveliness = rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+          } else if (liveliness_str == "LIVELINESS_MANUAL_BY_TOPIC" ||  // NOLINT
+            liveliness_str == "liveliness_manual_by_topic")
+          {
+            liveliness = rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
+          } else {
+            fprintf(
+              stderr,
+              "invalid value for 'liveliness': '%s', allowed values are "
+              "LIVELINESS_{SYSTEM_DEFAULT, AUTOMATIC, MANUAL_BY_TOPIC}, upper or lower case\n",
+              liveliness_str.c_str());
+          }
+
+          ros2_publisher_qos.liveliness(liveliness);
+          printf("liveliness: %s, ", liveliness_str.c_str());
+        } catch (std::runtime_error & e) {
+          fprintf(
+            stderr,
+            "failed to parse liveliness: '%s'\n",
+            e.what());
+        } catch (XmlRpc::XmlRpcException & e) {
+          fprintf(
+            stderr,
+            "failed to parse liveliness: '%s'\n",
+            e.getMessage().c_str());
+        }
+      } else {
+        fprintf(
+          stderr,
+          "failed to parse liveliness, parameter was not a string or int \n");
+      }
+    }
+
+    if (qos_params.hasMember("liveliness_lease_duration")) {
+      try {
+        rclcpp::Duration dur = rclcpp::Duration(
+          static_cast<int>(qos_params["liveliness_lease_duration"]["secs"]),
+          static_cast<int>(qos_params["liveliness_lease_duration"]["nsecs"]));
+        ros2_publisher_qos.liveliness_lease_duration(dur);
+        printf("liveliness_lease_duration: Duration(nsecs: %ld), ", dur.nanoseconds());
+      } catch (std::runtime_error & e) {
+        fprintf(
+          stderr,
+          "failed to parse liveliness_lease_duration: '%s'\n",
+          e.what());
+      } catch (XmlRpc::XmlRpcException & e) {
+        fprintf(
+          stderr,
+          "failed to parse liveliness_lease_duration: '%s'\n",
+          e.getMessage().c_str());
+      }
+    }
+  } else {
+    fprintf(
+      stderr,
+      "QoS parameters could not be read\n");
+  }
+
+  printf(")");
+  return ros2_publisher_qos;
+}
+
+bool find_command_option(const std::vector<std::string> & args, const std::string & option)
+{
+  return std::find(args.begin(), args.end(), option) != args.end();
+}
+
+bool get_flag_option(const std::vector<std::string> & args, const std::string & option)
+{
+  auto it = std::find(args.begin(), args.end(), option);
+  return it != args.end();
+}
+
+bool get_ros1_master_system_state(XmlRpc::XmlRpcValue &payload)
+{
+  XmlRpc::XmlRpcValue args, result;
+  args[0] = ros::this_node::getName();
+  if (!ros::master::execute("getSystemState", args, result, payload, true)) {
+    fprintf(stderr, "failed to get system state from ROS 1 master\n");
+    return false;
+  }
+  return true;
+}
+
+bool get_ros1_active_publishers(const XmlRpc::XmlRpcValue &payload, std::set<std::string> &active_publishers)
+{
+  // check publishers
+  if (payload.size() >= 1) {
+    for (int j = 0; j < payload[0].size(); ++j) {
+      std::string topic_name = payload[0][j][0];
+      for (int k = 0; k < payload[0][j][1].size(); ++k) {
+        std::string node_name = payload[0][j][1][k];
+        // ignore publishers from the bridge itself
+        if (node_name == ros::this_node::getName()) {
+          continue;
+        }
+        active_publishers.insert(topic_name);
+        break;
+      }
+    }
+  }
+  return true;
+}
+
+bool get_ros1_active_subscribers(const XmlRpc::XmlRpcValue &payload, std::set<std::string> &active_subscribers)
+{
+  // check subscribers
+  if (payload.size() >= 2) {
+    for (int j = 0; j < payload[1].size(); ++j) {
+      std::string topic_name = payload[1][j][0];
+      for (int k = 0; k < payload[1][j][1].size(); ++k) {
+        std::string node_name = payload[1][j][1][k];
+        // ignore subscribers from the bridge itself
+        if (node_name == ros::this_node::getName()) {
+          continue;
+        }
+        active_subscribers.insert(topic_name);
+        break;
+      }
+    }
+  }
+  return true;
+}
+
+void get_ros1_service_info(
+  const std::string name, std::map<std::string, std::map<std::string, std::string>> & ros1_services)
+{
+  // NOTE(rkozik):
+  // I tried to use Connection class but could not make it work
+  // auto callback = [](const ros::ConnectionPtr&, const ros::Header&)
+  //                 { printf("Callback\n"); return true; };
+  // ros::HeaderReceivedFunc f(callback);
+  // ros::ConnectionPtr connection(new ros::Connection);
+  // connection->initialize(transport, false, ros::HeaderReceivedFunc());
+  ros::ServiceManager manager;
+  std::string host;
+  std::uint32_t port;
+  if (!manager.lookupService(name, host, port)) {
+    fprintf(stderr, "Failed to look up %s\n", name.data());
+    return;
+  }
+  ros::TransportTCPPtr transport(new ros::TransportTCP(nullptr, ros::TransportTCP::SYNCHRONOUS));
+  auto transport_exit = rcpputils::make_scope_exit(
+    [transport]() {
+      transport->close();
+    });
+  if (!transport->connect(host, port)) {
+    fprintf(stderr, "Failed to connect to %s (%s:%d)\n", name.data(), host.data(), port);
+    return;
+  }
+  ros::M_string header_out;
+  header_out["probe"] = "1";
+  header_out["md5sum"] = "*";
+  header_out["service"] = name;
+  header_out["callerid"] = ros::this_node::getName();
+  boost::shared_array<uint8_t> buffer;
+  uint32_t len;
+  ros::Header::write(header_out, buffer, len);
+  std::vector<uint8_t> message(len + 4);
+  std::memcpy(&message[0], &len, 4);
+  std::memcpy(&message[4], buffer.get(), len);
+  transport->write(message.data(), message.size());
+  uint32_t length;
+  auto read = transport->read(reinterpret_cast<uint8_t *>(&length), 4);
+  if (read != 4) {
+    fprintf(stderr, "Failed to read a response from a service server\n");
+    return;
+  }
+  std::vector<uint8_t> response(length);
+  read = transport->read(response.data(), length);
+  if (read < 0 || static_cast<uint32_t>(read) != length) {
+    fprintf(stderr, "Failed to read a response from a service server\n");
+    return;
+  }
+  std::string key = name;
+  ros1_services[key] = std::map<std::string, std::string>();
+  ros::Header header_in;
+  std::string error;
+  auto success = header_in.parse(response.data(), length, error);
+  if (!success) {
+    fprintf(stderr, "%s\n", error.data());
+    return;
+  }
+  for (std::string field : {"type"}) {
+    std::string value;
+    auto success = header_in.getValue(field, value);
+    if (!success) {
+      fprintf(stderr, "Failed to read '%s' from a header for '%s'\n", field.data(), key.c_str());
+      ros1_services.erase(key);
+      return;
+    }
+    ros1_services[key][field] = value;
+  }
+  std::string t = ros1_services[key]["type"];
+  ros1_services[key]["package"] = std::string(t.begin(), t.begin() + t.find("/"));
+  ros1_services[key]["name"] = std::string(t.begin() + t.find("/") + 1, t.end());
+}
+
+bool get_ros1_current_topics(const std::set<std::string> &active_publishers,
+                        const std::set<std::string> &active_subscribers,
+                        std::map<std::string, std::string> &current_ros1_publishers,
+                        std::map<std::string, std::string> &current_ros1_subscribers,
+                        bool output_topic_introspection = false)
+{
+  // get message types for all topics
+  ros::master::V_TopicInfo topics;
+  bool success = ros::master::getTopics(topics);
+  if (!success) {
+    fprintf(stderr, "failed to poll ROS 1 master\n");
+    return false;
+  }
+
+  for (auto topic : topics) {
+    auto topic_name = topic.name;
+    bool has_publisher = active_publishers.find(topic_name) != active_publishers.end();
+    bool has_subscriber = active_subscribers.find(topic_name) != active_subscribers.end();
+    if (!has_publisher && !has_subscriber) {
+      // skip inactive topics
+      continue;
+    }
+    if (has_publisher) {
+      current_ros1_publishers[topic_name] = topic.datatype;
+    }
+    if (has_subscriber) {
+      current_ros1_subscribers[topic_name] = topic.datatype;
+    }
+    if (output_topic_introspection) {
+      printf(
+        "  ROS 1: %s (%s) [%s pubs, %s subs]\n",
+        topic_name.c_str(), topic.datatype.c_str(),
+        has_publisher ? ">0" : "0", has_subscriber ? ">0" : "0");
+    }
+  }
+
+  // since ROS 1 subscribers don't report their type they must be added anyway
+  for (auto active_subscriber : active_subscribers) {
+    if (current_ros1_subscribers.find(active_subscriber) == current_ros1_subscribers.end()) {
+      current_ros1_subscribers[active_subscriber] = "";
+      if (output_topic_introspection) {
+        printf("  ROS 1: %s (<unknown>) sub++\n", active_subscriber.c_str());
+      }
+    }
+  }
+
+  if (output_topic_introspection) {
+    printf("\n");
+  }
+  return true;
+}
+
+// check services
+bool get_ros1_services(const XmlRpc::XmlRpcValue &payload, std::map<std::string, std::map<std::string, std::string>> &ros1_services)
+{
+  if (payload.size() >= 3) {
+    for (int j = 0; j < payload[2].size(); ++j) {
+      if (payload[2][j][0].getType() == XmlRpc::XmlRpcValue::TypeString) {
+        std::string name = payload[2][j][0];
+        ros1_bridge::get_ros1_service_info(name, ros1_services);
+      }
+    }
+  }
+  return true;
+}
+
+void get_ros2_current_topics(rclcpp::Node::SharedPtr ros2_node,
+                            std::map<std::string, std::string> &current_ros2_publishers,
+                            std::map<std::string, std::string> &current_ros2_subscribers,
+                            std::map<std::string, Bridge1to2HandlesAndMessageTypes>& bridges_1to2,
+                            std::map<std::string, Bridge2to1HandlesAndMessageTypes>& bridges_2to1,
+                            std::set<std::string> &already_ignored_topics,
+                            bool output_topic_introspection=false)
+{
+  auto ros2_topics = ros2_node->get_topic_names_and_types();
+
+  std::set<std::string> ignored_topics;
+  ignored_topics.insert("parameter_events");
+
+  for (auto topic_and_types : ros2_topics) {
+    // ignore some common ROS 2 specific topics
+    if (ignored_topics.find(topic_and_types.first) != ignored_topics.end()) {
+      continue;
+    }
+
+    auto & topic_name = topic_and_types.first;
+    auto & topic_type = topic_and_types.second[0];  // explicitly take the first
+
+    // explicitly avoid topics with more than one type
+    if (topic_and_types.second.size() > 1) {
+      if (already_ignored_topics.count(topic_name) == 0) {
+        std::string types = "";
+        for (auto type : topic_and_types.second) {
+          types += type + ", ";
+        }
+        fprintf(
+          stderr,
+          "warning: ignoring topic '%s', which has more than one type: [%s]\n",
+          topic_name.c_str(),
+          types.substr(0, types.length() - 2).c_str()
+        );
+        already_ignored_topics.insert(topic_name);
+      }
+      continue;
+    }
+
+    auto publisher_count = ros2_node->count_publishers(topic_name);
+    auto subscriber_count = ros2_node->count_subscribers(topic_name);
+
+    // ignore publishers from the bridge itself
+    if (bridges_1to2.find(topic_name) != bridges_1to2.end()) {
+      if (publisher_count > 0) {
+        --publisher_count;
+      }
+    }
+    // ignore subscribers from the bridge itself
+    if (bridges_2to1.find(topic_name) != bridges_2to1.end()) {
+      if (subscriber_count > 0) {
+        --subscriber_count;
+      }
+    }
+
+    if (publisher_count) {
+      current_ros2_publishers[topic_name] = topic_type;
+    }
+
+    if (subscriber_count) {
+      current_ros2_subscribers[topic_name] = topic_type;
+    }
+
+    if (output_topic_introspection) {
+      printf(
+        "  ROS 2: %s (%s) [%zu pubs, %zu subs]\n",
+        topic_name.c_str(), topic_type.c_str(), publisher_count, subscriber_count);
+    }
+  }
+  if (output_topic_introspection) {
+    printf("\n");
+  }
+}
+
+void get_ros2_services(rclcpp::Node::SharedPtr ros2_node,
+                        std::map<std::string, std::map<std::string, std::string>> &active_ros2_services,
+                        std::set<std::string>& already_ignored_services)
+{
+  // collect available services (not clients)
+  std::set<std::string> service_names;
+  std::vector<std::pair<std::string, std::string>> node_names_and_namespaces =
+    ros2_node->get_node_graph_interface()->get_node_names_and_namespaces();
+  for (auto & pair : node_names_and_namespaces) {
+    if (pair.first == ros2_node->get_name() && pair.second == ros2_node->get_namespace()) {
+      continue;
+    }
+    std::map<std::string, std::vector<std::string>> services_and_types =
+      ros2_node->get_service_names_and_types_by_node(pair.first, pair.second);
+    for (auto & it : services_and_types) {
+      service_names.insert(it.first);
+    }
+  }
+
+  auto ros2_services_and_types = ros2_node->get_service_names_and_types();
+
+  for (const auto & service_and_types : ros2_services_and_types) {
+    auto & service_name = service_and_types.first;
+    auto & service_type = service_and_types.second[0];  // explicitly take the first
+
+    // explicitly avoid services with more than one type
+    if (service_and_types.second.size() > 1) {
+      if (already_ignored_services.count(service_name) == 0) {
+        std::string types = "";
+        for (auto type : service_and_types.second) {
+          types += type + ", ";
+        }
+        fprintf(
+          stderr,
+          "warning: ignoring service '%s', which has more than one type: [%s]\n",
+          service_name.c_str(),
+          types.substr(0, types.length() - 2).c_str()
+        );
+        already_ignored_services.insert(service_name);
+      }
+      continue;
+    }
+
+    // TODO(wjwwood): this should be common functionality in the C++ rosidl package
+    size_t separator_position = service_type.find('/');
+    if (separator_position == std::string::npos) {
+      fprintf(stderr, "invalid service type '%s', skipping...\n", service_type.c_str());
+      continue;
+    }
+
+    // only bridge if there is a service, not for a client
+    if (service_names.find(service_name) != service_names.end()) {
+      auto service_type_package_name = service_type.substr(0, separator_position);
+      auto service_type_srv_name = service_type.substr(separator_position + 1);
+      active_ros2_services[service_name]["package"] = service_type_package_name;
+      active_ros2_services[service_name]["name"] = service_type_srv_name;
+    }
+  }
+}
+} //namespace ros1_bridge

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -76,7 +76,8 @@ create_bridge_from_2_to_1(
   const std::string & ros1_type_name,
   const std::string & ros1_topic_name,
   size_t publisher_queue_size,
-  rclcpp::PublisherBase::SharedPtr ros2_pub)
+  rclcpp::PublisherBase::SharedPtr ros2_pub,
+  bool custom_callback_group)
 {
   auto subscriber_qos = rclcpp::SensorDataQoS(rclcpp::KeepLast(subscriber_queue_size));
   return create_bridge_from_2_to_1(
@@ -88,7 +89,8 @@ create_bridge_from_2_to_1(
     ros1_type_name,
     ros1_topic_name,
     publisher_queue_size,
-    ros2_pub);
+    ros2_pub,
+    custom_callback_group);
 }
 
 Bridge2to1Handles
@@ -101,14 +103,15 @@ create_bridge_from_2_to_1(
   const std::string & ros1_type_name,
   const std::string & ros1_topic_name,
   size_t publisher_queue_size,
-  rclcpp::PublisherBase::SharedPtr ros2_pub)
+  rclcpp::PublisherBase::SharedPtr ros2_pub,
+  bool custom_callback_group)
 {
   auto factory = get_factory(ros1_type_name, ros2_type_name);
   auto ros1_pub = factory->create_ros1_publisher(
     ros1_node, ros1_topic_name, publisher_queue_size);
 
   auto ros2_sub = factory->create_ros2_subscriber(
-    ros2_node, ros2_topic_name, subscriber_qos, ros1_pub, ros2_pub);
+    ros2_node, ros2_topic_name, subscriber_qos, ros1_pub, ros2_pub, custom_callback_group);
 
   Bridge2to1Handles handles;
   handles.ros2_subscriber = ros2_sub;
@@ -123,7 +126,8 @@ create_bidirectional_bridge(
   const std::string & ros1_type_name,
   const std::string & ros2_type_name,
   const std::string & topic_name,
-  size_t queue_size)
+  size_t queue_size,
+  bool custom_callback_group)
 {
   RCLCPP_INFO(
     ros2_node->get_logger(), "create bidirectional bridge for topic %s",
@@ -135,7 +139,7 @@ create_bidirectional_bridge(
   handles.bridge2to1 = create_bridge_from_2_to_1(
     ros2_node, ros1_node,
     ros2_type_name, topic_name, queue_size, ros1_type_name, topic_name, queue_size,
-    handles.bridge1to2.ros2_publisher);
+    handles.bridge1to2.ros2_publisher, custom_callback_group);
   return handles;
 }
 

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -136,8 +136,7 @@ void update_bridge(
   std::map<std::string, Bridge2to1HandlesAndMessageTypes> & bridges_2to1,
   std::map<std::string, ros1_bridge::ServiceBridge1to2> & service_bridges_1_to_2,
   std::map<std::string, ros1_bridge::ServiceBridge2to1> & service_bridges_2_to_1,
-  bool bridge_all_1to2_topics, bool bridge_all_2to1_topics,
-  std::vector<rclcpp::CallbackGroup::SharedPtr> & invalid_callback_group)
+  bool bridge_all_1to2_topics, bool bridge_all_2to1_topics)
 {
   std::lock_guard<std::mutex> lock(g_bridge_mutex);
 
@@ -359,8 +358,6 @@ void update_bridge(
     if (ros1_services.find(it->first) == ros1_services.end()) {
       printf("Removed 2 to 1 bridge for service %s\n", it->first.data());
       try {
-        // store the callback group to ensure that it is deleted after the node
-        invalid_callback_group.push_back(it->second.group);
         it = service_bridges_2_to_1.erase(it);
       } catch (std::runtime_error & e) {
         fprintf(stderr, "There was an error while removing 2 to 1 bridge: %s\n", e.what());
@@ -376,8 +373,6 @@ void update_bridge(
       printf("Removed 1 to 2 bridge for service %s\n", it->first.data());
       try {
         it->second.server.shutdown();
-        // store the callback group to ensure that it is deleted after the node
-        invalid_callback_group.push_back(it->second.group);
         it = service_bridges_1_to_2.erase(it);
       } catch (std::runtime_error & e) {
         fprintf(stderr, "There was an error while removing 1 to 2 bridge: %s\n", e.what());
@@ -477,6 +472,8 @@ int main(int argc, char * argv[])
   rclcpp::init(argc, argv);
 
   auto ros2_node = rclcpp::Node::make_shared("ros_bridge");
+  // a callback group for creating ros2 entity (client, service and subscription) later
+  auto callback_group = ros2_node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
 
   // ROS 1 node
   ros::init(argc, argv, "ros_bridge");
@@ -494,7 +491,6 @@ int main(int argc, char * argv[])
   std::map<std::string, Bridge2to1HandlesAndMessageTypes> bridges_2to1;
   std::map<std::string, ros1_bridge::ServiceBridge1to2> service_bridges_1_to_2;
   std::map<std::string, ros1_bridge::ServiceBridge2to1> service_bridges_2_to_1;
-  std::vector<rclcpp::CallbackGroup::SharedPtr> invalid_callback_group;
 
   // setup polling of ROS 1 master
   auto ros1_poll = [
@@ -505,8 +501,7 @@ int main(int argc, char * argv[])
     &ros1_services, &ros2_services,
     &service_bridges_1_to_2, &service_bridges_2_to_1,
     &output_topic_introspection,
-    &bridge_all_1to2_topics, &bridge_all_2to1_topics,
-    &invalid_callback_group
+    &bridge_all_1to2_topics, &bridge_all_2to1_topics
     ](const ros::TimerEvent &) -> void
     {
       // collect all topics names which have at least one publisher or subscriber beside this bridge
@@ -624,8 +619,7 @@ int main(int argc, char * argv[])
         ros1_services, ros2_services,
         bridges_1to2, bridges_2to1,
         service_bridges_1_to_2, service_bridges_2_to_1,
-        bridge_all_1to2_topics, bridge_all_2to1_topics,
-        invalid_callback_group);
+        bridge_all_1to2_topics, bridge_all_2to1_topics);
     };
 
   auto ros1_poll_timer = ros1_node.createTimer(ros::Duration(1.0), ros1_poll);
@@ -644,8 +638,7 @@ int main(int argc, char * argv[])
     &service_bridges_1_to_2, &service_bridges_2_to_1,
     &output_topic_introspection,
     &bridge_all_1to2_topics, &bridge_all_2to1_topics,
-    &already_ignored_topics, &already_ignored_services,
-    &invalid_callback_group
+    &already_ignored_topics, &already_ignored_services
     ]() -> void
     {
       auto ros2_topics = ros2_node->get_topic_names_and_types();
@@ -790,8 +783,7 @@ int main(int argc, char * argv[])
         ros1_services, ros2_services,
         bridges_1to2, bridges_2to1,
         service_bridges_1_to_2, service_bridges_2_to_1,
-        bridge_all_1to2_topics, bridge_all_2to1_topics,
-        invalid_callback_group);
+        bridge_all_1to2_topics, bridge_all_2to1_topics);
     };
 
   auto ros2_poll_timer = ros2_node->create_wall_timer(
@@ -806,7 +798,6 @@ int main(int argc, char * argv[])
   rclcpp::executors::MultiThreadedExecutor executor;
   while (ros1_node.ok() && rclcpp::ok()) {
     executor.spin_node_once(ros2_node);
-    invalid_callback_group.clear();
   }
 
   return 0;

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -786,9 +786,17 @@ int main(int argc, char * argv[])
         bridge_all_1to2_topics, bridge_all_2to1_topics);
     };
 
-  auto ros2_poll_timer = ros2_node->create_wall_timer(
-    std::chrono::seconds(1), ros2_poll);
+  auto check_ros1_flag = [&ros1_node] {
+      if (!ros1_node.ok()) {
+        rclcpp::shutdown();
+      }
+    };
 
+  auto ros2_poll_timer = ros2_node->create_wall_timer(
+    std::chrono::seconds(1), [&ros2_poll, &check_ros1_flag] {
+      ros2_poll();
+      check_ros1_flag();
+    });
 
   // ROS 1 asynchronous spinner
   ros::AsyncSpinner async_spinner(0);
@@ -796,9 +804,8 @@ int main(int argc, char * argv[])
 
   // ROS 2 spinning loop
   rclcpp::executors::MultiThreadedExecutor executor;
-  while (ros1_node.ok() && rclcpp::ok()) {
-    executor.spin_node_once(ros2_node);
-  }
+  executor.add_node(ros2_node);
+  executor.spin();
 
   return 0;
 }

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -473,14 +473,12 @@ int main(int argc, char * argv[])
   rclcpp::init(argc, argv);
 
   auto ros2_node = rclcpp::Node::make_shared("ros_bridge");
-  // a callback group for creating ros2 entity (client, service) later
-  auto callback_group = ros2_node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
 
   // ROS 1 node
   ros::init(argc, argv, "ros_bridge");
   ros::NodeHandle ros1_node;
-  ros::CallbackQueue queue;
-  ros1_node.setCallbackQueue(&queue);
+  ros::CallbackQueue ros1_callback_queue;
+  ros1_node.setCallbackQueue(&ros1_callback_queue);
 
   // mapping of available topic names to type names
   std::map<std::string, std::string> ros1_publishers;
@@ -794,7 +792,7 @@ int main(int argc, char * argv[])
 
 
   // ROS 1 asynchronous spinner
-  ros::AsyncSpinner async_spinner(0, &queue);
+  ros::AsyncSpinner async_spinner(0, &ros1_callback_queue);
   async_spinner.start();
 
   // ROS 2 spinning loop

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -472,7 +472,7 @@ int main(int argc, char * argv[])
   rclcpp::init(argc, argv);
 
   auto ros2_node = rclcpp::Node::make_shared("ros_bridge");
-  // a callback group for creating ros2 entity (client, service and subscription) later
+  // a callback group for creating ros2 entity (client, service) later
   auto callback_group = ros2_node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
 
   // ROS 1 node
@@ -786,17 +786,9 @@ int main(int argc, char * argv[])
         bridge_all_1to2_topics, bridge_all_2to1_topics);
     };
 
-  auto check_ros1_flag = [&ros1_node] {
-      if (!ros1_node.ok()) {
-        rclcpp::shutdown();
-      }
-    };
-
   auto ros2_poll_timer = ros2_node->create_wall_timer(
-    std::chrono::seconds(1), [&ros2_poll, &check_ros1_flag] {
-      ros2_poll();
-      check_ros1_flag();
-    });
+    std::chrono::seconds(1), ros2_poll);
+
 
   // ROS 1 asynchronous spinner
   ros::AsyncSpinner async_spinner(0);
@@ -804,8 +796,9 @@ int main(int argc, char * argv[])
 
   // ROS 2 spinning loop
   rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(ros2_node);
-  executor.spin();
+  while (ros1_node.ok() && rclcpp::ok()) {
+    executor.spin_node_once(ros2_node);
+  }
 
   return 0;
 }

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -136,7 +136,8 @@ void update_bridge(
   std::map<std::string, Bridge2to1HandlesAndMessageTypes> & bridges_2to1,
   std::map<std::string, ros1_bridge::ServiceBridge1to2> & service_bridges_1_to_2,
   std::map<std::string, ros1_bridge::ServiceBridge2to1> & service_bridges_2_to_1,
-  bool bridge_all_1to2_topics, bool bridge_all_2to1_topics)
+  bool bridge_all_1to2_topics, bool bridge_all_2to1_topics,
+  std::vector<rclcpp::CallbackGroup::SharedPtr> & invalid_callback_group)
 {
   std::lock_guard<std::mutex> lock(g_bridge_mutex);
 
@@ -358,6 +359,8 @@ void update_bridge(
     if (ros1_services.find(it->first) == ros1_services.end()) {
       printf("Removed 2 to 1 bridge for service %s\n", it->first.data());
       try {
+        // store the callback group to ensure that it is deleted after the node
+        invalid_callback_group.push_back(it->second.group);
         it = service_bridges_2_to_1.erase(it);
       } catch (std::runtime_error & e) {
         fprintf(stderr, "There was an error while removing 2 to 1 bridge: %s\n", e.what());
@@ -373,6 +376,8 @@ void update_bridge(
       printf("Removed 1 to 2 bridge for service %s\n", it->first.data());
       try {
         it->second.server.shutdown();
+        // store the callback group to ensure that it is deleted after the node
+        invalid_callback_group.push_back(it->second.group);
         it = service_bridges_1_to_2.erase(it);
       } catch (std::runtime_error & e) {
         fprintf(stderr, "There was an error while removing 1 to 2 bridge: %s\n", e.what());
@@ -489,6 +494,7 @@ int main(int argc, char * argv[])
   std::map<std::string, Bridge2to1HandlesAndMessageTypes> bridges_2to1;
   std::map<std::string, ros1_bridge::ServiceBridge1to2> service_bridges_1_to_2;
   std::map<std::string, ros1_bridge::ServiceBridge2to1> service_bridges_2_to_1;
+  std::vector<rclcpp::CallbackGroup::SharedPtr> invalid_callback_group;
 
   // setup polling of ROS 1 master
   auto ros1_poll = [
@@ -499,7 +505,8 @@ int main(int argc, char * argv[])
     &ros1_services, &ros2_services,
     &service_bridges_1_to_2, &service_bridges_2_to_1,
     &output_topic_introspection,
-    &bridge_all_1to2_topics, &bridge_all_2to1_topics
+    &bridge_all_1to2_topics, &bridge_all_2to1_topics,
+    &invalid_callback_group
     ](const ros::TimerEvent &) -> void
     {
       // collect all topics names which have at least one publisher or subscriber beside this bridge
@@ -617,7 +624,8 @@ int main(int argc, char * argv[])
         ros1_services, ros2_services,
         bridges_1to2, bridges_2to1,
         service_bridges_1_to_2, service_bridges_2_to_1,
-        bridge_all_1to2_topics, bridge_all_2to1_topics);
+        bridge_all_1to2_topics, bridge_all_2to1_topics,
+        invalid_callback_group);
     };
 
   auto ros1_poll_timer = ros1_node.createTimer(ros::Duration(1.0), ros1_poll);
@@ -636,7 +644,8 @@ int main(int argc, char * argv[])
     &service_bridges_1_to_2, &service_bridges_2_to_1,
     &output_topic_introspection,
     &bridge_all_1to2_topics, &bridge_all_2to1_topics,
-    &already_ignored_topics, &already_ignored_services
+    &already_ignored_topics, &already_ignored_services,
+    &invalid_callback_group
     ]() -> void
     {
       auto ros2_topics = ros2_node->get_topic_names_and_types();
@@ -781,7 +790,8 @@ int main(int argc, char * argv[])
         ros1_services, ros2_services,
         bridges_1to2, bridges_2to1,
         service_bridges_1_to_2, service_bridges_2_to_1,
-        bridge_all_1to2_topics, bridge_all_2to1_topics);
+        bridge_all_1to2_topics, bridge_all_2to1_topics,
+        invalid_callback_group);
     };
 
   auto ros2_poll_timer = ros2_node->create_wall_timer(
@@ -789,13 +799,14 @@ int main(int argc, char * argv[])
 
 
   // ROS 1 asynchronous spinner
-  ros::AsyncSpinner async_spinner(1);
+  ros::AsyncSpinner async_spinner(0);
   async_spinner.start();
 
   // ROS 2 spinning loop
-  rclcpp::executors::SingleThreadedExecutor executor;
+  rclcpp::executors::MultiThreadedExecutor executor;
   while (ros1_node.ok() && rclcpp::ok()) {
     executor.spin_node_once(ros2_node);
+    invalid_callback_group.clear();
   }
 
   return 0;

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -20,54 +20,9 @@
 #include <utility>
 #include <vector>
 
-// include ROS 1
-#ifdef __clang__
-# pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Wunused-parameter"
-#endif
-#include "ros/callback_queue.h"
-#include "ros/ros.h"
-#ifdef __clang__
-# pragma clang diagnostic pop
-#endif
-#include "ros/this_node.h"
-#include "ros/header.h"
-#include "ros/service_manager.h"
-#include "ros/transport/transport_tcp.h"
-
-// include ROS 2
-#include "rclcpp/rclcpp.hpp"
-#include "rcpputils/scope_exit.hpp"
-
-#include "ros1_bridge/bridge.hpp"
-
+#include "ros1_bridge/helper.hpp"
 
 std::mutex g_bridge_mutex;
-
-struct Bridge1to2HandlesAndMessageTypes
-{
-  ros1_bridge::Bridge1to2Handles bridge_handles;
-  std::string ros1_type_name;
-  std::string ros2_type_name;
-};
-
-struct Bridge2to1HandlesAndMessageTypes
-{
-  ros1_bridge::Bridge2to1Handles bridge_handles;
-  std::string ros1_type_name;
-  std::string ros2_type_name;
-};
-
-bool find_command_option(const std::vector<std::string> & args, const std::string & option)
-{
-  return std::find(args.begin(), args.end(), option) != args.end();
-}
-
-bool get_flag_option(const std::vector<std::string> & args, const std::string & option)
-{
-  auto it = std::find(args.begin(), args.end(), option);
-  return it != args.end();
-}
 
 bool parse_command_options(
   int argc, char ** argv, bool & output_topic_introspection,
@@ -76,7 +31,7 @@ bool parse_command_options(
 {
   std::vector<std::string> args(argv, argv + argc);
 
-  if (find_command_option(args, "-h") || find_command_option(args, "--help")) {
+  if (ros1_bridge::find_command_option(args, "-h") || ros1_bridge::find_command_option(args, "--help")) {
     std::stringstream ss;
     ss << "Usage:" << std::endl;
     ss << " -h, --help: This message." << std::endl;
@@ -96,7 +51,7 @@ bool parse_command_options(
     return false;
   }
 
-  if (get_flag_option(args, "--print-pairs")) {
+  if (ros1_bridge::get_flag_option(args, "--print-pairs")) {
     auto mappings_2to1 = ros1_bridge::get_all_message_mappings_2to1();
     if (mappings_2to1.size() > 0) {
       printf("Supported ROS 2 <=> ROS 1 message type conversion pairs:\n");
@@ -118,12 +73,12 @@ bool parse_command_options(
     return false;
   }
 
-  output_topic_introspection = get_flag_option(args, "--show-introspection");
+  output_topic_introspection = ros1_bridge::get_flag_option(args, "--show-introspection");
 
-  bool bridge_all_topics = get_flag_option(args, "--bridge-all-topics");
-  bridge_all_1to2_topics = bridge_all_topics || get_flag_option(args, "--bridge-all-1to2-topics");
-  bridge_all_2to1_topics = bridge_all_topics || get_flag_option(args, "--bridge-all-2to1-topics");
-  multi_threads = get_flag_option(args, "--multi-threads");
+  bool bridge_all_topics = ros1_bridge::get_flag_option(args, "--bridge-all-topics");
+  bridge_all_1to2_topics = bridge_all_topics || ros1_bridge::get_flag_option(args, "--bridge-all-1to2-topics");
+  bridge_all_2to1_topics = bridge_all_topics || ros1_bridge::get_flag_option(args, "--bridge-all-2to1-topics");
+  multi_threads = ros1_bridge::get_flag_option(args, "--multi-threads");
 
   return true;
 }
@@ -137,8 +92,8 @@ void update_bridge(
   const std::map<std::string, std::string> & ros2_subscribers,
   const std::map<std::string, std::map<std::string, std::string>> & ros1_services,
   const std::map<std::string, std::map<std::string, std::string>> & ros2_services,
-  std::map<std::string, Bridge1to2HandlesAndMessageTypes> & bridges_1to2,
-  std::map<std::string, Bridge2to1HandlesAndMessageTypes> & bridges_2to1,
+  std::map<std::string, ros1_bridge::Bridge1to2HandlesAndMessageTypes> & bridges_1to2,
+  std::map<std::string, ros1_bridge::Bridge2to1HandlesAndMessageTypes> & bridges_2to1,
   std::map<std::string, ros1_bridge::ServiceBridge1to2> & service_bridges_1_to_2,
   std::map<std::string, ros1_bridge::ServiceBridge2to1> & service_bridges_2_to_1,
   bool bridge_all_1to2_topics, bool bridge_all_2to1_topics,
@@ -183,7 +138,7 @@ void update_bridge(
       printf("replace 1to2 bridge for topic '%s'\n", topic_name.c_str());
     }
 
-    Bridge1to2HandlesAndMessageTypes bridge;
+    ros1_bridge::Bridge1to2HandlesAndMessageTypes bridge;
     bridge.ros1_type_name = ros1_type_name;
     bridge.ros2_type_name = ros2_type_name;
 
@@ -254,7 +209,7 @@ void update_bridge(
       printf("replace 2to1 bridge for topic '%s'\n", topic_name.c_str());
     }
 
-    Bridge2to1HandlesAndMessageTypes bridge;
+    ros1_bridge::Bridge2to1HandlesAndMessageTypes bridge;
     bridge.ros1_type_name = ros1_type_name;
     bridge.ros2_type_name = ros2_type_name;
 
@@ -392,80 +347,6 @@ void update_bridge(
   }
 }
 
-void get_ros1_service_info(
-  const std::string name, std::map<std::string, std::map<std::string, std::string>> & ros1_services)
-{
-  // NOTE(rkozik):
-  // I tried to use Connection class but could not make it work
-  // auto callback = [](const ros::ConnectionPtr&, const ros::Header&)
-  //                 { printf("Callback\n"); return true; };
-  // ros::HeaderReceivedFunc f(callback);
-  // ros::ConnectionPtr connection(new ros::Connection);
-  // connection->initialize(transport, false, ros::HeaderReceivedFunc());
-  ros::ServiceManager manager;
-  std::string host;
-  std::uint32_t port;
-  if (!manager.lookupService(name, host, port)) {
-    fprintf(stderr, "Failed to look up %s\n", name.data());
-    return;
-  }
-  ros::TransportTCPPtr transport(new ros::TransportTCP(nullptr, ros::TransportTCP::SYNCHRONOUS));
-  auto transport_exit = rcpputils::make_scope_exit(
-    [transport]() {
-      transport->close();
-    });
-  if (!transport->connect(host, port)) {
-    fprintf(stderr, "Failed to connect to %s (%s:%d)\n", name.data(), host.data(), port);
-    return;
-  }
-  ros::M_string header_out;
-  header_out["probe"] = "1";
-  header_out["md5sum"] = "*";
-  header_out["service"] = name;
-  header_out["callerid"] = ros::this_node::getName();
-  boost::shared_array<uint8_t> buffer;
-  uint32_t len;
-  ros::Header::write(header_out, buffer, len);
-  std::vector<uint8_t> message(len + 4);
-  std::memcpy(&message[0], &len, 4);
-  std::memcpy(&message[4], buffer.get(), len);
-  transport->write(message.data(), message.size());
-  uint32_t length;
-  auto read = transport->read(reinterpret_cast<uint8_t *>(&length), 4);
-  if (read != 4) {
-    fprintf(stderr, "Failed to read a response from a service server\n");
-    return;
-  }
-  std::vector<uint8_t> response(length);
-  read = transport->read(response.data(), length);
-  if (read < 0 || static_cast<uint32_t>(read) != length) {
-    fprintf(stderr, "Failed to read a response from a service server\n");
-    return;
-  }
-  std::string key = name;
-  ros1_services[key] = std::map<std::string, std::string>();
-  ros::Header header_in;
-  std::string error;
-  auto success = header_in.parse(response.data(), length, error);
-  if (!success) {
-    fprintf(stderr, "%s\n", error.data());
-    return;
-  }
-  for (std::string field : {"type"}) {
-    std::string value;
-    auto success = header_in.getValue(field, value);
-    if (!success) {
-      fprintf(stderr, "Failed to read '%s' from a header for '%s'\n", field.data(), key.c_str());
-      ros1_services.erase(key);
-      return;
-    }
-    ros1_services[key][field] = value;
-  }
-  std::string t = ros1_services[key]["type"];
-  ros1_services[key]["package"] = std::string(t.begin(), t.begin() + t.find("/"));
-  ros1_services[key]["name"] = std::string(t.begin() + t.find("/") + 1, t.end());
-}
-
 int main(int argc, char * argv[])
 {
   bool output_topic_introspection;
@@ -502,8 +383,8 @@ int main(int argc, char * argv[])
   std::map<std::string, std::map<std::string, std::string>> ros1_services;
   std::map<std::string, std::map<std::string, std::string>> ros2_services;
 
-  std::map<std::string, Bridge1to2HandlesAndMessageTypes> bridges_1to2;
-  std::map<std::string, Bridge2to1HandlesAndMessageTypes> bridges_2to1;
+  std::map<std::string, ros1_bridge::Bridge1to2HandlesAndMessageTypes> bridges_1to2;
+  std::map<std::string, ros1_bridge::Bridge2to1HandlesAndMessageTypes> bridges_2to1;
   std::map<std::string, ros1_bridge::ServiceBridge1to2> service_bridges_1_to_2;
   std::map<std::string, ros1_bridge::ServiceBridge2to1> service_bridges_2_to_1;
 
@@ -523,107 +404,25 @@ int main(int argc, char * argv[])
       // collect all topics names which have at least one publisher or subscriber beside this bridge
       std::set<std::string> active_publishers;
       std::set<std::string> active_subscribers;
+      std::map<std::string, std::string> current_ros1_publishers;
+      std::map<std::string, std::string> current_ros1_subscribers;
+      std::map<std::string, std::map<std::string, std::string>> active_ros1_services;
 
-      XmlRpc::XmlRpcValue args, result, payload;
-      args[0] = ros::this_node::getName();
-      if (!ros::master::execute("getSystemState", args, result, payload, true)) {
-        fprintf(stderr, "failed to get system state from ROS 1 master\n");
+      XmlRpc::XmlRpcValue payload;
+      if(!ros1_bridge::get_ros1_master_system_state(payload)) {
         return;
       }
-      // check publishers
-      if (payload.size() >= 1) {
-        for (int j = 0; j < payload[0].size(); ++j) {
-          std::string topic_name = payload[0][j][0];
-          for (int k = 0; k < payload[0][j][1].size(); ++k) {
-            std::string node_name = payload[0][j][1][k];
-            // ignore publishers from the bridge itself
-            if (node_name == ros::this_node::getName()) {
-              continue;
-            }
-            active_publishers.insert(topic_name);
-            break;
-          }
-        }
-      }
-      // check subscribers
-      if (payload.size() >= 2) {
-        for (int j = 0; j < payload[1].size(); ++j) {
-          std::string topic_name = payload[1][j][0];
-          for (int k = 0; k < payload[1][j][1].size(); ++k) {
-            std::string node_name = payload[1][j][1][k];
-            // ignore subscribers from the bridge itself
-            if (node_name == ros::this_node::getName()) {
-              continue;
-            }
-            active_subscribers.insert(topic_name);
-            break;
-          }
-        }
-      }
 
-      // check services
-      std::map<std::string, std::map<std::string, std::string>> active_ros1_services;
-      if (payload.size() >= 3) {
-        for (int j = 0; j < payload[2].size(); ++j) {
-          if (payload[2][j][0].getType() == XmlRpc::XmlRpcValue::TypeString) {
-            std::string name = payload[2][j][0];
-            get_ros1_service_info(name, active_ros1_services);
-          }
-        }
-      }
+      ros1_bridge::get_ros1_active_publishers(payload, active_publishers);
+      ros1_bridge::get_ros1_active_subscribers(payload, active_subscribers);
+      ros1_bridge::get_ros1_current_topics(active_publishers, active_subscribers,
+                                          current_ros1_publishers, current_ros1_subscribers,
+                                          output_topic_introspection);
+      ros1_bridge::get_ros1_services(payload, active_ros1_services);
+
       {
         std::lock_guard<std::mutex> lock(g_bridge_mutex);
         ros1_services = active_ros1_services;
-      }
-
-      // get message types for all topics
-      ros::master::V_TopicInfo topics;
-      bool success = ros::master::getTopics(topics);
-      if (!success) {
-        fprintf(stderr, "failed to poll ROS 1 master\n");
-        return;
-      }
-
-      std::map<std::string, std::string> current_ros1_publishers;
-      std::map<std::string, std::string> current_ros1_subscribers;
-      for (auto topic : topics) {
-        auto topic_name = topic.name;
-        bool has_publisher = active_publishers.find(topic_name) != active_publishers.end();
-        bool has_subscriber = active_subscribers.find(topic_name) != active_subscribers.end();
-        if (!has_publisher && !has_subscriber) {
-          // skip inactive topics
-          continue;
-        }
-        if (has_publisher) {
-          current_ros1_publishers[topic_name] = topic.datatype;
-        }
-        if (has_subscriber) {
-          current_ros1_subscribers[topic_name] = topic.datatype;
-        }
-        if (output_topic_introspection) {
-          printf(
-            "  ROS 1: %s (%s) [%s pubs, %s subs]\n",
-            topic_name.c_str(), topic.datatype.c_str(),
-            has_publisher ? ">0" : "0", has_subscriber ? ">0" : "0");
-        }
-      }
-
-      // since ROS 1 subscribers don't report their type they must be added anyway
-      for (auto active_subscriber : active_subscribers) {
-        if (current_ros1_subscribers.find(active_subscriber) == current_ros1_subscribers.end()) {
-          current_ros1_subscribers[active_subscriber] = "";
-          if (output_topic_introspection) {
-            printf("  ROS 1: %s (<unknown>) sub++\n", active_subscriber.c_str());
-          }
-        }
-      }
-
-      if (output_topic_introspection) {
-        printf("\n");
-      }
-
-      {
-        std::lock_guard<std::mutex> lock(g_bridge_mutex);
         ros1_publishers = current_ros1_publishers;
         ros1_subscribers = current_ros1_subscribers;
       }
@@ -659,137 +458,19 @@ int main(int argc, char * argv[])
     multi_threads
     ]() -> void
     {
-      auto ros2_topics = ros2_node->get_topic_names_and_types();
-
-      std::set<std::string> ignored_topics;
-      ignored_topics.insert("parameter_events");
-
       std::map<std::string, std::string> current_ros2_publishers;
       std::map<std::string, std::string> current_ros2_subscribers;
-      for (auto topic_and_types : ros2_topics) {
-        // ignore some common ROS 2 specific topics
-        if (ignored_topics.find(topic_and_types.first) != ignored_topics.end()) {
-          continue;
-        }
-
-        auto & topic_name = topic_and_types.first;
-        auto & topic_type = topic_and_types.second[0];  // explicitly take the first
-
-        // explicitly avoid topics with more than one type
-        if (topic_and_types.second.size() > 1) {
-          if (already_ignored_topics.count(topic_name) == 0) {
-            std::string types = "";
-            for (auto type : topic_and_types.second) {
-              types += type + ", ";
-            }
-            fprintf(
-              stderr,
-              "warning: ignoring topic '%s', which has more than one type: [%s]\n",
-              topic_name.c_str(),
-              types.substr(0, types.length() - 2).c_str()
-            );
-            already_ignored_topics.insert(topic_name);
-          }
-          continue;
-        }
-
-        auto publisher_count = ros2_node->count_publishers(topic_name);
-        auto subscriber_count = ros2_node->count_subscribers(topic_name);
-
-        // ignore publishers from the bridge itself
-        if (bridges_1to2.find(topic_name) != bridges_1to2.end()) {
-          if (publisher_count > 0) {
-            --publisher_count;
-          }
-        }
-        // ignore subscribers from the bridge itself
-        if (bridges_2to1.find(topic_name) != bridges_2to1.end()) {
-          if (subscriber_count > 0) {
-            --subscriber_count;
-          }
-        }
-
-        if (publisher_count) {
-          current_ros2_publishers[topic_name] = topic_type;
-        }
-
-        if (subscriber_count) {
-          current_ros2_subscribers[topic_name] = topic_type;
-        }
-
-        if (output_topic_introspection) {
-          printf(
-            "  ROS 2: %s (%s) [%zu pubs, %zu subs]\n",
-            topic_name.c_str(), topic_type.c_str(), publisher_count, subscriber_count);
-        }
-      }
-
-      // collect available services (not clients)
-      std::set<std::string> service_names;
-      std::vector<std::pair<std::string, std::string>> node_names_and_namespaces =
-        ros2_node->get_node_graph_interface()->get_node_names_and_namespaces();
-      for (auto & pair : node_names_and_namespaces) {
-        if (pair.first == ros2_node->get_name() && pair.second == ros2_node->get_namespace()) {
-          continue;
-        }
-        std::map<std::string, std::vector<std::string>> services_and_types =
-          ros2_node->get_service_names_and_types_by_node(pair.first, pair.second);
-        for (auto & it : services_and_types) {
-          service_names.insert(it.first);
-        }
-      }
-
-      auto ros2_services_and_types = ros2_node->get_service_names_and_types();
       std::map<std::string, std::map<std::string, std::string>> active_ros2_services;
-      for (const auto & service_and_types : ros2_services_and_types) {
-        auto & service_name = service_and_types.first;
-        auto & service_type = service_and_types.second[0];  // explicitly take the first
 
-        // explicitly avoid services with more than one type
-        if (service_and_types.second.size() > 1) {
-          if (already_ignored_services.count(service_name) == 0) {
-            std::string types = "";
-            for (auto type : service_and_types.second) {
-              types += type + ", ";
-            }
-            fprintf(
-              stderr,
-              "warning: ignoring service '%s', which has more than one type: [%s]\n",
-              service_name.c_str(),
-              types.substr(0, types.length() - 2).c_str()
-            );
-            already_ignored_services.insert(service_name);
-          }
-          continue;
-        }
-
-        // TODO(wjwwood): this should be common functionality in the C++ rosidl package
-        size_t separator_position = service_type.find('/');
-        if (separator_position == std::string::npos) {
-          fprintf(stderr, "invalid service type '%s', skipping...\n", service_type.c_str());
-          continue;
-        }
-
-        // only bridge if there is a service, not for a client
-        if (service_names.find(service_name) != service_names.end()) {
-          auto service_type_package_name = service_type.substr(0, separator_position);
-          auto service_type_srv_name = service_type.substr(separator_position + 1);
-          active_ros2_services[service_name]["package"] = service_type_package_name;
-          active_ros2_services[service_name]["name"] = service_type_srv_name;
-        }
-      }
+      ros1_bridge::get_ros2_current_topics(ros2_node,
+                                            current_ros2_publishers, current_ros2_subscribers,
+                                            bridges_1to2, bridges_2to1,
+                                            already_ignored_topics, output_topic_introspection);
+      ros1_bridge::get_ros2_services(ros2_node, active_ros2_services, already_ignored_services);
 
       {
         std::lock_guard<std::mutex> lock(g_bridge_mutex);
         ros2_services = active_ros2_services;
-      }
-
-      if (output_topic_introspection) {
-        printf("\n");
-      }
-
-      {
-        std::lock_guard<std::mutex> lock(g_bridge_mutex);
         ros2_publishers = current_ros2_publishers;
         ros2_subscribers = current_ros2_subscribers;
       }

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -71,7 +71,8 @@ bool get_flag_option(const std::vector<std::string> & args, const std::string & 
 
 bool parse_command_options(
   int argc, char ** argv, bool & output_topic_introspection,
-  bool & bridge_all_1to2_topics, bool & bridge_all_2to1_topics)
+  bool & bridge_all_1to2_topics, bool & bridge_all_2to1_topics,
+  bool & multi_threads)
 {
   std::vector<std::string> args(argv, argv + argc);
 
@@ -89,6 +90,8 @@ bool parse_command_options(
     ss << "a matching subscriber." << std::endl;
     ss << " --bridge-all-2to1-topics: Bridge all ROS 2 topics to ROS 1, whether or not there is ";
     ss << "a matching subscriber." << std::endl;
+    ss << " --multi-threads: Bridge with multiple threads for spinner of ROS 1 and ROS 2.";
+    ss << std::endl;
     std::cout << ss.str();
     return false;
   }
@@ -120,6 +123,7 @@ bool parse_command_options(
   bool bridge_all_topics = get_flag_option(args, "--bridge-all-topics");
   bridge_all_1to2_topics = bridge_all_topics || get_flag_option(args, "--bridge-all-1to2-topics");
   bridge_all_2to1_topics = bridge_all_topics || get_flag_option(args, "--bridge-all-2to1-topics");
+  multi_threads = get_flag_option(args, "--multi-threads");
 
   return true;
 }
@@ -137,7 +141,8 @@ void update_bridge(
   std::map<std::string, Bridge2to1HandlesAndMessageTypes> & bridges_2to1,
   std::map<std::string, ros1_bridge::ServiceBridge1to2> & service_bridges_1_to_2,
   std::map<std::string, ros1_bridge::ServiceBridge2to1> & service_bridges_2_to_1,
-  bool bridge_all_1to2_topics, bool bridge_all_2to1_topics)
+  bool bridge_all_1to2_topics, bool bridge_all_2to1_topics,
+  bool multi_threads = false)
 {
   std::lock_guard<std::mutex> lock(g_bridge_mutex);
 
@@ -257,7 +262,9 @@ void update_bridge(
       bridge.bridge_handles = ros1_bridge::create_bridge_from_2_to_1(
         ros2_node, ros1_node,
         bridge.ros2_type_name, topic_name, 10,
-        bridge.ros1_type_name, topic_name, 10);
+        bridge.ros1_type_name, topic_name, 10,
+        nullptr,
+        multi_threads);
     } catch (std::runtime_error & e) {
       fprintf(
         stderr,
@@ -319,7 +326,8 @@ void update_bridge(
         "ros1", details.at("package"), details.at("name"));
       if (factory) {
         try {
-          service_bridges_2_to_1[name] = factory->service_bridge_2_to_1(ros1_node, ros2_node, name);
+          service_bridges_2_to_1[name] = factory->service_bridge_2_to_1(
+            ros1_node, ros2_node, name, multi_threads);
           printf("Created 2 to 1 bridge for service %s\n", name.data());
         } catch (std::runtime_error & e) {
           fprintf(stderr, "Failed to created a bridge: %s\n", e.what());
@@ -345,7 +353,7 @@ void update_bridge(
       if (factory) {
         try {
           service_bridges_1_to_2[name] = factory->service_bridge_1_to_2(
-            ros1_node, ros2_node, name, service_execution_timeout);
+            ros1_node, ros2_node, name, service_execution_timeout, multi_threads);
           printf("Created 1 to 2 bridge for service %s\n", name.data());
         } catch (std::runtime_error & e) {
           fprintf(stderr, "Failed to created a bridge: %s\n", e.what());
@@ -463,8 +471,10 @@ int main(int argc, char * argv[])
   bool output_topic_introspection;
   bool bridge_all_1to2_topics;
   bool bridge_all_2to1_topics;
+  bool multi_threads;
   if (!parse_command_options(
-      argc, argv, output_topic_introspection, bridge_all_1to2_topics, bridge_all_2to1_topics))
+      argc, argv, output_topic_introspection, bridge_all_1to2_topics, bridge_all_2to1_topics,
+      multi_threads))
   {
     return 0;
   }
@@ -477,8 +487,12 @@ int main(int argc, char * argv[])
   // ROS 1 node
   ros::init(argc, argv, "ros_bridge");
   ros::NodeHandle ros1_node;
-  ros::CallbackQueue ros1_callback_queue;
-  ros1_node.setCallbackQueue(&ros1_callback_queue);
+  std::unique_ptr<ros::CallbackQueue> ros1_callback_queue = nullptr;
+  if (multi_threads) {
+    ros1_callback_queue = std::make_unique<ros::CallbackQueue>();
+    ros1_node.setCallbackQueue(ros1_callback_queue.get());
+  }
+
 
   // mapping of available topic names to type names
   std::map<std::string, std::string> ros1_publishers;
@@ -502,7 +516,8 @@ int main(int argc, char * argv[])
     &ros1_services, &ros2_services,
     &service_bridges_1_to_2, &service_bridges_2_to_1,
     &output_topic_introspection,
-    &bridge_all_1to2_topics, &bridge_all_2to1_topics
+    &bridge_all_1to2_topics, &bridge_all_2to1_topics,
+    multi_threads
     ](const ros::TimerEvent &) -> void
     {
       // collect all topics names which have at least one publisher or subscriber beside this bridge
@@ -620,7 +635,8 @@ int main(int argc, char * argv[])
         ros1_services, ros2_services,
         bridges_1to2, bridges_2to1,
         service_bridges_1_to_2, service_bridges_2_to_1,
-        bridge_all_1to2_topics, bridge_all_2to1_topics);
+        bridge_all_1to2_topics, bridge_all_2to1_topics,
+        multi_threads);
     };
 
   auto ros1_poll_timer = ros1_node.createTimer(ros::Duration(1.0), ros1_poll);
@@ -639,7 +655,8 @@ int main(int argc, char * argv[])
     &service_bridges_1_to_2, &service_bridges_2_to_1,
     &output_topic_introspection,
     &bridge_all_1to2_topics, &bridge_all_2to1_topics,
-    &already_ignored_topics, &already_ignored_services
+    &already_ignored_topics, &already_ignored_services,
+    multi_threads
     ]() -> void
     {
       auto ros2_topics = ros2_node->get_topic_names_and_types();
@@ -784,22 +801,41 @@ int main(int argc, char * argv[])
         ros1_services, ros2_services,
         bridges_1to2, bridges_2to1,
         service_bridges_1_to_2, service_bridges_2_to_1,
-        bridge_all_1to2_topics, bridge_all_2to1_topics);
+        bridge_all_1to2_topics, bridge_all_2to1_topics,
+        multi_threads);
+    };
+
+  auto check_ros1_flag = [&ros1_node] {
+      if (!ros1_node.ok()) {
+        rclcpp::shutdown();
+      }
     };
 
   auto ros2_poll_timer = ros2_node->create_wall_timer(
-    std::chrono::seconds(1), ros2_poll);
+    std::chrono::seconds(1), [&ros2_poll, &check_ros1_flag] {
+      ros2_poll();
+      check_ros1_flag();
+    });
 
 
   // ROS 1 asynchronous spinner
-  ros::AsyncSpinner async_spinner(0, &ros1_callback_queue);
-  async_spinner.start();
+  std::unique_ptr<ros::AsyncSpinner> async_spinner = nullptr;
+  if (!multi_threads) {
+    async_spinner = std::make_unique<ros::AsyncSpinner>(1);
+  } else {
+    async_spinner = std::make_unique<ros::AsyncSpinner>(0, ros1_callback_queue.get());
+  }
+  async_spinner->start();
 
   // ROS 2 spinning loop
-  rclcpp::executors::MultiThreadedExecutor executor;
-  while (ros1_node.ok() && rclcpp::ok()) {
-    executor.spin_node_once(ros2_node);
+  std::unique_ptr<rclcpp::Executor> executor = nullptr;
+  if (!multi_threads) {
+    executor = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+  } else {
+    executor = std::make_unique<rclcpp::executors::MultiThreadedExecutor>();
   }
+  executor->add_node(ros2_node);
+  executor->spin();
 
   return 0;
 }

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -25,6 +25,7 @@
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Wunused-parameter"
 #endif
+#include "ros/callback_queue.h"
 #include "ros/ros.h"
 #ifdef __clang__
 # pragma clang diagnostic pop
@@ -478,6 +479,8 @@ int main(int argc, char * argv[])
   // ROS 1 node
   ros::init(argc, argv, "ros_bridge");
   ros::NodeHandle ros1_node;
+  ros::CallbackQueue queue;
+  ros1_node.setCallbackQueue(&queue);
 
   // mapping of available topic names to type names
   std::map<std::string, std::string> ros1_publishers;
@@ -791,7 +794,7 @@ int main(int argc, char * argv[])
 
 
   // ROS 1 asynchronous spinner
-  ros::AsyncSpinner async_spinner(0);
+  ros::AsyncSpinner async_spinner(0, &queue);
   async_spinner.start();
 
   // ROS 2 spinning loop

--- a/test/test_services_across_dynamic_bridge.py.in
+++ b/test/test_services_across_dynamic_bridge.py.in
@@ -27,6 +27,7 @@ TEST_BRIDGE_ROSCORE = '@TEST_BRIDGE_ROSCORE@'
 TEST_BRIDGE_ROS1_CLIENT = '@TEST_BRIDGE_ROS1_CLIENT@'
 TEST_BRIDGE_ROS1_SERVER = '@TEST_BRIDGE_ROS1_SERVER@'
 TEST_BRIDGE_DYNAMIC_BRIDGE = '@TEST_BRIDGE_DYNAMIC_BRIDGE@'
+TEST_BRIDGE_DYNAMIC_BRIDGE_ARG = '@TEST_BRIDGE_DYNAMIC_BRIDGE_ARG@'
 TEST_BRIDGE_ROS2_CLIENT = '@TEST_BRIDGE_ROS2_CLIENT@'
 TEST_BRIDGE_ROS2_SERVER = '@TEST_BRIDGE_ROS2_SERVER@'
 
@@ -50,7 +51,7 @@ def generate_test_description(test_name, server_cmd, client_cmd):
 
     # dynamic bridge
     rosbridge_process = ExecuteProcess(
-        cmd=[TEST_BRIDGE_ROS1_ENV, TEST_BRIDGE_DYNAMIC_BRIDGE],
+        cmd=[TEST_BRIDGE_ROS1_ENV, TEST_BRIDGE_DYNAMIC_BRIDGE, TEST_BRIDGE_DYNAMIC_BRIDGE_ARG],
         name=test_name + '__dynamic_bridge',
     )
     launch_description.add_action(rosbridge_process)

--- a/test/test_topics_across_dynamic_bridge.py.in
+++ b/test/test_topics_across_dynamic_bridge.py.in
@@ -33,6 +33,7 @@ TEST_BRIDGE_ROSCORE = '@TEST_BRIDGE_ROSCORE@'
 TEST_BRIDGE_ROS1_TALKER = ['rosrun', 'roscpp_tutorials', 'talker']
 TEST_BRIDGE_ROS1_LISTENER = ['rosrun', 'rospy_tutorials', 'listener']
 TEST_BRIDGE_DYNAMIC_BRIDGE = '@TEST_BRIDGE_DYNAMIC_BRIDGE@'
+TEST_BRIDGE_DYNAMIC_BRIDGE_ARG = '@TEST_BRIDGE_DYNAMIC_BRIDGE_ARG@'
 TEST_BRIDGE_ROS2_TALKER = get_executable_path(
     package_name='demo_nodes_cpp', executable_name='talker')
 TEST_BRIDGE_ROS2_LISTENER = get_executable_path(
@@ -59,7 +60,7 @@ def generate_test_description(test_name, talker_cmd, listener_cmd, logs_stream):
 
     # dynamic bridge
     rosbridge_process = ExecuteProcess(
-        cmd=[TEST_BRIDGE_ROS1_ENV, TEST_BRIDGE_DYNAMIC_BRIDGE],
+        cmd=[TEST_BRIDGE_ROS1_ENV, TEST_BRIDGE_DYNAMIC_BRIDGE, TEST_BRIDGE_DYNAMIC_BRIDGE_ARG],
         name=test_name + '__dynamic_bridge',
     )
     launch_description.add_action(rosbridge_process)


### PR DESCRIPTION
ref:
- https://github.com/4am-robotics/orga/issues/2540
- https://github.com/4am-robotics/orga/issues/2536

fixes:
- do not throw std::runtime exceptions on failed ros1 service calls. To catch and handle them at this location, modifications to the idl needs to take place
- enable multithreaded spinners to allow concurrent service handling
- periodically update the services on parameter_bridge like the dynamic_bridge to allow recovery of lost services
- clean up