### PR TITLE
Fix message mapping by removing early return so other rules can still apply

### DIFF
--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -1050,7 +1050,6 @@ def determine_field_mapping(ros1_msg, ros2_msg, mapping_rules, msg_idx):
                     file=sys.stderr)
                 continue
             mapping.add_field_pair(ros1_selected_fields, ros2_selected_fields)
-        return mapping
 
     # apply name based mapping of fields
     ros1_field_missing_in_ros2 = False


### PR DESCRIPTION
https://github.com/ros2/ros1_bridge/pull/380 applied to mojin-devel on our fork