### PR TITLE
Account for fields mapped by rules when checking for missed fields

### DIFF
--- a/include/ros1_bridge/action_factory.hpp
+++ b/include/ros1_bridge/action_factory.hpp
@@ -394,7 +394,7 @@ private:
 
   std::size_t get_goal_id_hash(const rclcpp_action::GoalUUID & uuid)
   {
-    return std::hash<rclcpp_action::GoalUUID>{}(uuid);
+    return std::hash<rclcpp_action::GoalUUID>{} (uuid);
   }
 
   ros::NodeHandle ros1_node_;

--- a/include/ros1_bridge/builtin_interfaces_factories.hpp
+++ b/include/ros1_bridge/builtin_interfaces_factories.hpp
@@ -19,12 +19,12 @@
 #include <std_msgs/Duration.h>
 #include <std_msgs/Time.h>
 
-#include <memory>
-#include <string>
-
 // include ROS 2 messages
 #include <builtin_interfaces/msg/duration.hpp>
 #include <builtin_interfaces/msg/time.hpp>
+
+#include <memory>
+#include <string>
 
 #include "ros1_bridge/factory.hpp"
 

--- a/include/ros1_bridge/helper.hpp
+++ b/include/ros1_bridge/helper.hpp
@@ -19,6 +19,11 @@
 
 #include <list>
 #include <string>
+#include <vector>
+#include <set>
+#include <map>
+#include <utility>
+
 
 // include ROS 1
 #ifdef __clang__
@@ -276,7 +281,8 @@ bool get_ros1_master_system_state(XmlRpc::XmlRpcValue &payload)
   return true;
 }
 
-bool get_ros1_active_publishers(const XmlRpc::XmlRpcValue &payload, std::set<std::string> &active_publishers)
+bool get_ros1_active_publishers(const XmlRpc::XmlRpcValue &payload,
+                                std::set<std::string> &active_publishers)
 {
   // check publishers
   if (payload.size() >= 1) {
@@ -296,7 +302,8 @@ bool get_ros1_active_publishers(const XmlRpc::XmlRpcValue &payload, std::set<std
   return true;
 }
 
-bool get_ros1_active_subscribers(const XmlRpc::XmlRpcValue &payload, std::set<std::string> &active_subscribers)
+bool get_ros1_active_subscribers(const XmlRpc::XmlRpcValue &payload,
+                                 std::set<std::string> &active_subscribers)
 {
   // check subscribers
   if (payload.size() >= 2) {
@@ -443,7 +450,8 @@ bool get_ros1_current_topics(const std::set<std::string> &active_publishers,
 }
 
 // check services
-bool get_ros1_services(const XmlRpc::XmlRpcValue &payload, std::map<std::string, std::map<std::string, std::string>> &ros1_services)
+bool get_ros1_services(const XmlRpc::XmlRpcValue &payload,
+                       std::map<std::string, std::map<std::string, std::string>> &ros1_services)
 {
   if (payload.size() >= 3) {
     for (int j = 0; j < payload[2].size(); ++j) {
@@ -462,7 +470,7 @@ void get_ros2_current_topics(rclcpp::Node::SharedPtr ros2_node,
                             std::map<std::string, Bridge1to2HandlesAndMessageTypes>& bridges_1to2,
                             std::map<std::string, Bridge2to1HandlesAndMessageTypes>& bridges_2to1,
                             std::set<std::string> &already_ignored_topics,
-                            bool output_topic_introspection=false)
+                            bool output_topic_introspection = false)
 {
   auto ros2_topics = ros2_node->get_topic_names_and_types();
 
@@ -532,7 +540,8 @@ void get_ros2_current_topics(rclcpp::Node::SharedPtr ros2_node,
 }
 
 void get_ros2_services(rclcpp::Node::SharedPtr ros2_node,
-                        std::map<std::string, std::map<std::string, std::string>> &active_ros2_services,
+                        std::map<std::string, std::map<std::string, std::string>>
+                          &active_ros2_services,
                         std::set<std::string>& already_ignored_services)
 {
   // collect available services (not clients)
@@ -590,6 +599,6 @@ void get_ros2_services(rclcpp::Node::SharedPtr ros2_node,
     }
   }
 }
-} //namespace ros1_bridge
+}  // namespace ros1_bridge
 
 #endif  // ROS1_BRIDGE__HELPER_HPP_

--- a/include/ros1_bridge/helper.hpp
+++ b/include/ros1_bridge/helper.hpp
@@ -17,6 +17,9 @@
 
 #include <xmlrpcpp/XmlRpcException.h>
 
+#include <list>
+#include <string>
+
 // include ROS 1
 #ifdef __clang__
 # pragma clang diagnostic push
@@ -35,9 +38,6 @@
 // include ROS 2
 #include "rclcpp/rclcpp.hpp"
 #include "rcpputils/scope_exit.hpp"
-
-#include <list>
-#include <string>
 
 #include "ros1_bridge/bridge.hpp"
 

--- a/include/ros1_bridge/helper.hpp
+++ b/include/ros1_bridge/helper.hpp
@@ -46,7 +46,8 @@
 
 #include "ros1_bridge/bridge.hpp"
 
-namespace ros1_bridge {
+namespace ros1_bridge
+{
 
 struct Bridge1to2HandlesAndMessageTypes
 {
@@ -270,7 +271,7 @@ bool get_flag_option(const std::vector<std::string> & args, const std::string & 
   return it != args.end();
 }
 
-bool get_ros1_master_system_state(XmlRpc::XmlRpcValue &payload)
+bool get_ros1_master_system_state(XmlRpc::XmlRpcValue & payload)
 {
   XmlRpc::XmlRpcValue args, result;
   args[0] = ros::this_node::getName();
@@ -281,8 +282,9 @@ bool get_ros1_master_system_state(XmlRpc::XmlRpcValue &payload)
   return true;
 }
 
-bool get_ros1_active_publishers(const XmlRpc::XmlRpcValue &payload,
-                                std::set<std::string> &active_publishers)
+bool get_ros1_active_publishers(
+  const XmlRpc::XmlRpcValue & payload,
+  std::set<std::string> & active_publishers)
 {
   // check publishers
   if (payload.size() >= 1) {
@@ -302,8 +304,9 @@ bool get_ros1_active_publishers(const XmlRpc::XmlRpcValue &payload,
   return true;
 }
 
-bool get_ros1_active_subscribers(const XmlRpc::XmlRpcValue &payload,
-                                 std::set<std::string> &active_subscribers)
+bool get_ros1_active_subscribers(
+  const XmlRpc::XmlRpcValue & payload,
+  std::set<std::string> & active_subscribers)
 {
   // check subscribers
   if (payload.size() >= 2) {
@@ -397,11 +400,12 @@ void get_ros1_service_info(
   ros1_services[key]["name"] = std::string(t.begin() + t.find("/") + 1, t.end());
 }
 
-bool get_ros1_current_topics(const std::set<std::string> &active_publishers,
-                        const std::set<std::string> &active_subscribers,
-                        std::map<std::string, std::string> &current_ros1_publishers,
-                        std::map<std::string, std::string> &current_ros1_subscribers,
-                        bool output_topic_introspection = false)
+bool get_ros1_current_topics(
+  const std::set<std::string> & active_publishers,
+  const std::set<std::string> & active_subscribers,
+  std::map<std::string, std::string> & current_ros1_publishers,
+  std::map<std::string, std::string> & current_ros1_subscribers,
+  bool output_topic_introspection = false)
 {
   // get message types for all topics
   ros::master::V_TopicInfo topics;
@@ -450,8 +454,9 @@ bool get_ros1_current_topics(const std::set<std::string> &active_publishers,
 }
 
 // check services
-bool get_ros1_services(const XmlRpc::XmlRpcValue &payload,
-                       std::map<std::string, std::map<std::string, std::string>> &ros1_services)
+bool get_ros1_services(
+  const XmlRpc::XmlRpcValue & payload,
+  std::map<std::string, std::map<std::string, std::string>> & ros1_services)
 {
   if (payload.size() >= 3) {
     for (int j = 0; j < payload[2].size(); ++j) {
@@ -464,13 +469,14 @@ bool get_ros1_services(const XmlRpc::XmlRpcValue &payload,
   return true;
 }
 
-void get_ros2_current_topics(rclcpp::Node::SharedPtr ros2_node,
-                            std::map<std::string, std::string> &current_ros2_publishers,
-                            std::map<std::string, std::string> &current_ros2_subscribers,
-                            std::map<std::string, Bridge1to2HandlesAndMessageTypes>& bridges_1to2,
-                            std::map<std::string, Bridge2to1HandlesAndMessageTypes>& bridges_2to1,
-                            std::set<std::string> &already_ignored_topics,
-                            bool output_topic_introspection = false)
+void get_ros2_current_topics(
+  rclcpp::Node::SharedPtr ros2_node,
+  std::map<std::string, std::string> & current_ros2_publishers,
+  std::map<std::string, std::string> & current_ros2_subscribers,
+  std::map<std::string, Bridge1to2HandlesAndMessageTypes> & bridges_1to2,
+  std::map<std::string, Bridge2to1HandlesAndMessageTypes> & bridges_2to1,
+  std::set<std::string> & already_ignored_topics,
+  bool output_topic_introspection = false)
 {
   auto ros2_topics = ros2_node->get_topic_names_and_types();
 
@@ -539,10 +545,11 @@ void get_ros2_current_topics(rclcpp::Node::SharedPtr ros2_node,
   }
 }
 
-void get_ros2_services(rclcpp::Node::SharedPtr ros2_node,
-                        std::map<std::string, std::map<std::string, std::string>>
-                          &active_ros2_services,
-                        std::set<std::string>& already_ignored_services)
+void get_ros2_services(
+  rclcpp::Node::SharedPtr ros2_node,
+  std::map<std::string, std::map<std::string, std::string>>
+  & active_ros2_services,
+  std::set<std::string> & already_ignored_services)
 {
   // collect available services (not clients)
   std::set<std::string> service_names;

--- a/include/ros1_bridge/helper.hpp
+++ b/include/ros1_bridge/helper.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
-
+#ifndef ROS1_BRIDGE__HELPER_HPP_
+#define ROS1_BRIDGE__HELPER_HPP_
 
 #include <xmlrpcpp/XmlRpcException.h>
 
@@ -591,3 +591,5 @@ void get_ros2_services(rclcpp::Node::SharedPtr ros2_node,
   }
 }
 } //namespace ros1_bridge
+
+#endif  // ROS1_BRIDGE__HELPER_HPP_

--- a/include/ros1_bridge/helper.hpp
+++ b/include/ros1_bridge/helper.hpp
@@ -1,3 +1,17 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -1066,7 +1066,7 @@ def determine_field_mapping(ros1_msg, ros2_msg, mapping_rules, msg_idx):
         ros1_fields_mapped_to_a_ros2_member = [field[0].name
                                                for field
                                                in mapping.fields_1_to_2.keys()]
-        if not ros1_field.name in ros1_fields_mapped_to_a_ros2_member:
+        if ros1_field.name not in ros1_fields_mapped_to_a_ros2_member:
             # this allows fields to exist in ROS 1 but not in ROS 2
             ros1_fields_not_mapped += [ros1_field]
 

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -466,7 +466,8 @@ def get_ros2_actions():
                         'ros1_service_name', 'ros2_service_name'))):
                     try:
                         rules.append(ActionMappingRule(data, package_name))
-                    except Exception as e:
+                    # MappingRule raises a plain Exception, a custom exception could be better
+                    except Exception as e:  # noqa: B902
                         print('%s' % str(e), file=sys.stderr)
     return pkgs, actions, rules
 

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -71,6 +71,10 @@ for package_path in reversed([p for p in rpp if p]):
 import rosmsg  # noqa
 
 
+class MappingException(Exception):
+    pass
+
+
 def generate_cpp(output_path, template_dir):
     rospack = rospkg.RosPack()
     data = generate_messages(rospack)
@@ -336,7 +340,7 @@ def get_ros2_messages():
                 if all(n not in data for n in ('ros1_service_name', 'ros2_service_name')):
                     try:
                         rules.append(MessageMappingRule(data, package_name))
-                    except Exception as e:  # noqa: B902
+                    except MappingException as e:
                         print('%s' % str(e), file=sys.stderr)
     return pkgs, msgs, rules
 
@@ -399,7 +403,7 @@ def get_ros2_services():
                 if all(n not in data for n in ('ros1_message_name', 'ros2_message_name')):
                     try:
                         rules.append(ServiceMappingRule(data, package_name))
-                    except Exception as e:  # noqa: B902
+                    except MappingException as e:
                         print('%s' % str(e), file=sys.stderr)
     return pkgs, srvs, rules
 
@@ -466,8 +470,7 @@ def get_ros2_actions():
                         'ros1_service_name', 'ros2_service_name'))):
                     try:
                         rules.append(ActionMappingRule(data, package_name))
-                    # MappingRule raises a plain Exception, a custom exception could be better
-                    except Exception as e:  # noqa: B902
+                    except MappingException as e:
                         print('%s' % str(e), file=sys.stderr)
     return pkgs, actions, rules
 
@@ -510,7 +513,7 @@ class MappingRule:
         if all(n in data for n in ('ros1_package_name', 'ros2_package_name')):
             if (data['ros2_package_name'] != expected_package_name
                     and not data.get('enable_foreign_mappings')):
-                raise Exception(
+                raise MappingException(
                     ('Ignoring rule which affects a different ROS 2 package (%s) '
                      'then the one it is defined in (%s)\n\n'
                      '(Please set `enable_foreign_mappings` to `true` if '
@@ -524,7 +527,7 @@ class MappingRule:
                 len(data) == (2 + int('enable_foreign_mappings' in data))
             )
         else:
-            raise Exception(
+            raise MappingException(
                 'Ignoring a rule without a ros1_package_name and/or ros2_package_name')
 
     def is_package_mapping(self):

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -1054,6 +1054,7 @@ def determine_field_mapping(ros1_msg, ros2_msg, mapping_rules, msg_idx):
     # apply name based mapping of fields
     ros1_field_missing_in_ros2 = False
 
+    ros1_fields_not_mapped = []
     for ros1_field in ros1_spec.parsed_fields():
         for ros2_member in ros2_spec.structure.members:
             if ros1_field.name.lower() == ros2_member.name:
@@ -1061,9 +1062,15 @@ def determine_field_mapping(ros1_msg, ros2_msg, mapping_rules, msg_idx):
                 update_ros1_field_information(ros1_field, ros1_msg.package_name)
                 mapping.add_field_pair(ros1_field, ros2_member)
                 break
-        else:
+
+        ros1_fields_mapped_to_a_ros2_member = [field[0].name
+                                               for field
+                                               in mapping.fields_1_to_2.keys()]
+        if not ros1_field.name in ros1_fields_mapped_to_a_ros2_member:
             # this allows fields to exist in ROS 1 but not in ROS 2
-            ros1_field_missing_in_ros2 = True
+            ros1_fields_not_mapped += [ros1_field]
+
+    ros1_field_missing_in_ros2 = any(ros1_fields_not_mapped)
 
     if ros1_field_missing_in_ros2:
         # if some fields exist in ROS 1 but not in ROS 2

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -34,8 +34,9 @@ bool parse_command_options(
 {
   std::vector<std::string> args(argv, argv + argc);
 
-  if (ros1_bridge::find_command_option(args, "-h")
-      || ros1_bridge::find_command_option(args, "--help")) {
+  if (ros1_bridge::find_command_option(args, "-h") ||
+    ros1_bridge::find_command_option(args, "--help"))
+  {
     std::stringstream ss;
     ss << "Usage:" << std::endl;
     ss << " -h, --help: This message." << std::endl;
@@ -89,10 +90,10 @@ bool parse_command_options(
   output_topic_introspection = ros1_bridge::get_flag_option(args, "--show-introspection");
 
   bool bridge_all_topics = ros1_bridge::get_flag_option(args, "--bridge-all-topics");
-  bridge_all_1to2_topics = bridge_all_topics
-                           || ros1_bridge::get_flag_option(args, "--bridge-all-1to2-topics");
-  bridge_all_2to1_topics = bridge_all_topics
-                           || ros1_bridge::get_flag_option(args, "--bridge-all-2to1-topics");
+  bridge_all_1to2_topics = bridge_all_topics ||
+    ros1_bridge::get_flag_option(args, "--bridge-all-1to2-topics");
+  bridge_all_2to1_topics = bridge_all_topics ||
+    ros1_bridge::get_flag_option(args, "--bridge-all-2to1-topics");
   multi_threads = ros1_bridge::get_flag_option(args, "--multi-threads");
 
   return true;
@@ -720,20 +721,21 @@ int main(int argc, char * argv[])
       std::map<std::string, std::map<std::string, std::string>> active_ros1_services;
 
       XmlRpc::XmlRpcValue payload;
-      if(!ros1_bridge::get_ros1_master_system_state(payload)) {
+      if (!ros1_bridge::get_ros1_master_system_state(payload)) {
         return;
       }
 
       ros1_bridge::get_ros1_active_publishers(payload, active_publishers);
       ros1_bridge::get_ros1_active_subscribers(payload, active_subscribers);
-      ros1_bridge::get_ros1_current_topics(active_publishers, active_subscribers,
-                                          current_ros1_publishers, current_ros1_subscribers,
-                                          output_topic_introspection);
+      ros1_bridge::get_ros1_current_topics(
+        active_publishers, active_subscribers,
+        current_ros1_publishers, current_ros1_subscribers,
+        output_topic_introspection);
       ros1_bridge::get_ros1_services(payload, active_ros1_services);
 
       // check actions
       std::map<std::string, std::map<std::string, std::string>>
-        active_ros1_action_servers, active_ros1_action_clients;
+      active_ros1_action_servers, active_ros1_action_clients;
       get_active_ros1_actions(
         current_ros1_publishers, current_ros1_subscribers,
         active_ros1_action_servers, active_ros1_action_clients);
@@ -797,10 +799,11 @@ int main(int argc, char * argv[])
       std::map<std::string, std::string> current_ros2_subscribers;
       std::map<std::string, std::map<std::string, std::string>> active_ros2_services;
 
-      ros1_bridge::get_ros2_current_topics(ros2_node,
-                                            current_ros2_publishers, current_ros2_subscribers,
-                                            bridges_1to2, bridges_2to1,
-                                            already_ignored_topics, output_topic_introspection);
+      ros1_bridge::get_ros2_current_topics(
+        ros2_node,
+        current_ros2_publishers, current_ros2_subscribers,
+        bridges_1to2, bridges_2to1,
+        already_ignored_topics, output_topic_introspection);
       ros1_bridge::get_ros2_services(ros2_node, active_ros2_services, already_ignored_services);
 
       std::map<std::string, std::map<std::string, std::string>> active_ros2_action_servers,

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <boost/algorithm/string/predicate.hpp>
+
 #include <cstring>
 #include <map>
 #include <memory>
@@ -19,7 +21,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <boost/algorithm/string/predicate.hpp>
 
 #include "ros1_bridge/helper.hpp"
 #include "ros1_bridge/action_factory.hpp"
@@ -33,7 +34,8 @@ bool parse_command_options(
 {
   std::vector<std::string> args(argv, argv + argc);
 
-  if (ros1_bridge::find_command_option(args, "-h") || ros1_bridge::find_command_option(args, "--help")) {
+  if (ros1_bridge::find_command_option(args, "-h")
+      || ros1_bridge::find_command_option(args, "--help")) {
     std::stringstream ss;
     ss << "Usage:" << std::endl;
     ss << " -h, --help: This message." << std::endl;
@@ -87,8 +89,10 @@ bool parse_command_options(
   output_topic_introspection = ros1_bridge::get_flag_option(args, "--show-introspection");
 
   bool bridge_all_topics = ros1_bridge::get_flag_option(args, "--bridge-all-topics");
-  bridge_all_1to2_topics = bridge_all_topics || ros1_bridge::get_flag_option(args, "--bridge-all-1to2-topics");
-  bridge_all_2to1_topics = bridge_all_topics || ros1_bridge::get_flag_option(args, "--bridge-all-2to1-topics");
+  bridge_all_1to2_topics = bridge_all_topics
+                           || ros1_bridge::get_flag_option(args, "--bridge-all-1to2-topics");
+  bridge_all_2to1_topics = bridge_all_topics
+                           || ros1_bridge::get_flag_option(args, "--bridge-all-2to1-topics");
   multi_threads = ros1_bridge::get_flag_option(args, "--multi-threads");
 
   return true;
@@ -728,7 +732,8 @@ int main(int argc, char * argv[])
       ros1_bridge::get_ros1_services(payload, active_ros1_services);
 
       // check actions
-      std::map<std::string, std::map<std::string, std::string>> active_ros1_action_servers, active_ros1_action_clients;
+      std::map<std::string, std::map<std::string, std::string>>
+        active_ros1_action_servers, active_ros1_action_clients;
       get_active_ros1_actions(
         current_ros1_publishers, current_ros1_subscribers,
         active_ros1_action_servers, active_ros1_action_clients);

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -26,12 +26,13 @@
 std::mutex g_bridge_mutex;
 
 bool parse_command_options(
-  int argc, char ** argv, bool &multi_threads)
+  int argc, char ** argv, bool & multi_threads)
 {
   std::vector<std::string> args(argv, argv + argc);
 
-  if (ros1_bridge::find_command_option(args, "-h")
-      || ros1_bridge::find_command_option(args, "--help")) {
+  if (ros1_bridge::find_command_option(args, "-h") ||
+    ros1_bridge::find_command_option(args, "--help"))
+  {
     std::stringstream ss;
     ss << "Usage:" << std::endl;
     ss << " -h, --help: This message." << std::endl;
@@ -76,13 +77,12 @@ void update_services(
           service_bridges_2_to_1.find(name) == service_bridges_2_to_1.end() &&
           service_bridges_1_to_2.find(name) == service_bridges_1_to_2.end())
         {
-          if(name != service_name)
-          {
+          if (name != service_name) {
             continue;
           }
           std::stringstream ss;
           ss << details.at("package") << "/" << details.at("name");
-          if(service_type == ss.str()) {
+          if (service_type == ss.str()) {
             auto factory = ros1_bridge::get_service_factory(
               "ros1", details.at("package"), details.at("name"));
             if (factory) {
@@ -95,9 +95,10 @@ void update_services(
               }
             }
           } else {
-            fprintf(stderr,
-                    "Failed to created a bridge for service %s. types differ\n",
-                    name.c_str());
+            fprintf(
+              stderr,
+              "Failed to created a bridge for service %s. types differ\n",
+              name.c_str());
           }
         }
       }
@@ -128,13 +129,12 @@ void update_services(
           service_bridges_1_to_2.find(name) == service_bridges_1_to_2.end() &&
           service_bridges_2_to_1.find(name) == service_bridges_2_to_1.end())
         {
-          if(name != service_name)
-          {
+          if (name != service_name) {
             continue;
           }
           std::stringstream ss;
           ss << details.at("package") << "/" << details.at("name");
-          if(service_type == ss.str()) {
+          if (service_type == ss.str()) {
             auto factory = ros1_bridge::get_service_factory(
               "ros2", details.at("package"), details.at("name"));
             if (factory) {
@@ -147,9 +147,10 @@ void update_services(
               }
             }
           } else {
-            fprintf(stderr,
-                    "Failed to created a bridge for service %s. types differ\n",
-                    name.c_str());
+            fprintf(
+              stderr,
+              "Failed to created a bridge for service %s. types differ\n",
+              name.c_str());
           }
         }
       }
@@ -190,8 +191,9 @@ int main(int argc, char * argv[])
 {
   bool multi_threads;
 
-  if (!parse_command_options(argc, argv, multi_threads))
+  if (!parse_command_options(argc, argv, multi_threads)) {
     return 0;
+  }
 
   // ROS 2 node
   rclcpp::init(argc, argv);
@@ -297,7 +299,7 @@ int main(int argc, char * argv[])
       std::map<std::string, std::map<std::string, std::string>> active_ros1_services;
 
       XmlRpc::XmlRpcValue payload;
-      if(!ros1_bridge::get_ros1_master_system_state(payload)) {
+      if (!ros1_bridge::get_ros1_master_system_state(payload)) {
         return;
       }
 
@@ -347,10 +349,10 @@ int main(int argc, char * argv[])
     };
 
   auto check_ros1_flag = [&ros1_node] {
-    if (!ros1_node.ok()) {
-      rclcpp::shutdown();
-    }
-  };
+      if (!ros1_node.ok()) {
+        rclcpp::shutdown();
+      }
+    };
 
   auto ros2_poll_timer = ros2_node->create_wall_timer(
     std::chrono::seconds(1), [&ros2_poll, &check_ros1_flag] {

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -17,6 +17,9 @@
 #include <memory>
 #include <list>
 #include <string>
+#include <vector>
+#include <map>
+#include <set>
 
 #include "ros1_bridge/helper.hpp"
 
@@ -27,7 +30,8 @@ bool parse_command_options(
 {
   std::vector<std::string> args(argv, argv + argc);
 
-  if (ros1_bridge::find_command_option(args, "-h") || ros1_bridge::find_command_option(args, "--help")) {
+  if (ros1_bridge::find_command_option(args, "-h")
+      || ros1_bridge::find_command_option(args, "--help")) {
     std::stringstream ss;
     ss << "Usage:" << std::endl;
     ss << " -h, --help: This message." << std::endl;
@@ -90,9 +94,10 @@ void update_services(
                 fprintf(stderr, "Failed to created a bridge: %s\n", e.what());
               }
             }
-          }
-          else {
-            fprintf(stderr, "Failed to created a bridge for service %s. types differ\n", name.c_str());
+          } else {
+            fprintf(stderr,
+                    "Failed to created a bridge for service %s. types differ\n",
+                    name.c_str());
           }
         }
       }
@@ -110,7 +115,7 @@ void update_services(
     services_1_to_2.getType() == XmlRpc::XmlRpcValue::TypeArray)
   {
     for (size_t i = 0; i < static_cast<size_t>(services_1_to_2.size()); ++i) {
-      //first check if this service is already in the map saved
+      // first check if this service is already in the map saved
 
       std::string service_name = static_cast<std::string>(services_1_to_2[i]["service"]);
       std::string service_type = static_cast<std::string>(services_1_to_2[i]["type"]);
@@ -141,9 +146,10 @@ void update_services(
                 fprintf(stderr, "Failed to created a bridge: %s\n", e.what());
               }
             }
-          }
-          else {
-            fprintf(stderr, "Failed to created a bridge for service %s. types differ\n", name.c_str());
+          } else {
+            fprintf(stderr,
+                    "Failed to created a bridge for service %s. types differ\n",
+                    name.c_str());
           }
         }
       }


### PR DESCRIPTION
Fixup for #4 and https://github.com/ros2/ros1_bridge/pull/382 applied on top of `mojin-devel`

The code after the early return mentioned in the previous commit assumed all fields would match by name, which was of course true. But not anymore, so the missing check now only fails when the missing fields are also not already accounted for via a mapping

To test:
Put 
```yaml
  - topic: /test_id
    type: unique_identifier_msgs/msg/UUID
    queue_size: 1
  - topic: /gazebo_stuff
    type: gazebo_msgs/msg/ODEJointProperties
    queue_size: 1
```

in eg. `amr_config/robots/common/ros1_ros2_bridge.yaml`
and start `source_amr_ros_bridge && ROBOT=mrl-2 start_amr_ros_bridge`

Then run
```bash
source_amr_ros2 && ros2 topic pub /test_id unique_identifier_msgs/msg/UUID "uuid: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2]"

source_amr_ros1 && rostopic echo /test_id
```

```bash
source_amr_ros1 && rostopic pub /test_id uuid_msgs/UniqueID "uuid: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]" -r1

source_amr_ros2 && ros2 topic echo /test_id
```

```bash
source_amr_ros2 && ros2 topic pub /gazebo_stuff gazebo_msgs/msg/ODEJointProperties "damping: []
hi_stop: [10]
lo_stop: [11]
erp: [12]
cfm: [13]
stop_erp: [14]
stop_cfm: [15]
fudge_factor: [16]
fmax: [17]
vel: [18]" -r 1

source_amr_ros1 && rostopic echo /gazebo_stuff
```

```bash
source_amr_ros1 && rostopic pub /gazebo_stuff gazebo_msgs/ODEJointProperties "damping: [1]
hiStop: [2]
loStop: [3]
erp: [4]
cfm: [5]
stop_erp: [6]
stop_cfm: [7]
fudge_factor: [8]
fmax: [9]
vel: [10]"  -r 1

source_amr_ros2 && ros2 topic echo /gazebo_stuff gazebo_msgs/msg/ODEJointProperties
```
